### PR TITLE
feat: [UI 파운데이션] 쿨 팔레트 전환, HeroStatus, frosted glass 헤더, 햄버거 메뉴

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -8,11 +8,7 @@ MegaBobs Phase 1 구현을 돕는 프로젝트 레벨 Claude 스킬 모음입니
 
 | 스킬 | 폴더 | 목적 | 발동 시점 |
 |---|---|---|---|
-| create-pr | `create-pr/` | diff 분석 → 구조화된 PR 본문(요약·Changes 테이블·Mermaid·테스트 계획) 생성 후 `gh pr create`. 슬래시 커맨드 [`/pr`](../commands/pr.md) 과 동일 절차 (✅ 작성 완료) | "PR 만들어줘" 등 PR 생성 요청 시 |
-| 디자인 시스템 가드 | `design-system-guard/` | Phase 1 디자인 토큰·컨벤션(각진 모서리, 단일 옐로우 키컬러 `#E2C04C`, UI 이모지 금지, Pretendard/Noto Serif KR)을 UI 구현 시 강제 | 컴포넌트·스타일 작성/리뷰 시 |
-| 컴포넌트 스캐폴딩 | `component-scaffold/` | 프로젝트 컨벤션(arrow fn + `export default`, 네이밍, import 순서, 300줄/80줄 제한)에 맞춰 새 컴포넌트·페이지 생성 | 새 컴포넌트/페이지 추가 시 |
-| API 라우트 패턴 | `api-route-pattern/` | Next.js Route Handler + Supabase + 인증/캐시 패턴을 따르는 새 API 엔드포인트 생성 | `src/app/api/*` 추가 시 |
-| Supabase 스키마 작업 | `supabase-schema/` | 투표·메뉴·맛집 등 테이블/마이그레이션과 타입·쿼리 레이어를 일관되게 작성 | 새 테이블/스키마 변경 시 |
+| create-pr | `create-pr/` | diff 분석 → 구조화된 PR 본문(요약·Changes 테이블·Mermaid·테스트 계획) 생성 후 `gh pr create`. 슬래시 커맨드 [`/pr`](../commands/pr.md) 과 동일 절차 | "PR 만들어줘" 등 PR 생성 요청 시 |
 
 ## 작성 가이드
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,18 +6,18 @@
 
 ## Product Context
 
-- **무엇인가:** 메가존 임직원용 구내식당 점심 허브 — 날짜·코스별 식단 조회, (예정) 투표·내기 게임·지정타 맛집.
+- **무엇인가:** 메가존 임직원용 구내식당 메뉴 뷰어 — 날짜·코스별 식단 조회, 실시간 운영 상태 표시, Slack 봇 연동.
 - **누구를 위한가:** 과천 지식정보타운 메가존 직원. 점심 직전 "오늘 뭐 먹지"를 30초 안에 해결하려는 사람.
-- **공간/업종:** 사내 유틸리티 + 점심 커뮤니티. 식단표(메뉴판)가 1차 정체성.
+- **공간/업종:** 사내 유틸리티. 식단표(메뉴판)가 1차 정체성.
 - **프로젝트 타입:** 모바일 우선 반응형 웹앱(App UI). 마케팅 사이트 아님.
-- **기억에 남길 한 가지:** "각진 메뉴판" — 둥근 SaaS 카드가 아니라, 옐로우 키컬러 한 점이 박힌 흑백 에디토리얼 식단표.
+- **기억에 남길 한 가지:** 토스 느낌의 쿨 팔레트 — near-black + clean white + cool blue-tint, 경계선 없는 shadow-only 카드.
 
 ## Aesthetic Direction
 
-- **방향:** 비스트로 테라코타 / 에디토리얼 — 푸드 웜톤 리브랜딩(기존 블루 폐기). 메뉴판 무드, 식단 스캔 속도 우선.
-- **데코레이션 레벨:** minimal — 타이포와 여백이 일한다. 그림자는 헤어라인 + 미세 섀도뿐. 장식 블롭·그라데이션 데코 금지.
-- **무드:** 차분한 흑백 베이스에 옐로우 한 점. 진지하지만 친근한 사내 도구.
-- **레퍼런스:** Figma `Db40M9n99faf18mk211nM4`, `docs/design/mockups`.
+- **방향:** Toss 톤앤매너 참고 — 쿨 블루틴트 배경 + near-black 잉크 + shadow-only elevation. 경계선 없음.
+- **데코레이션 레벨:** minimal — 타이포와 여백이 일한다. 그림자로 깊이 표현. 장식 블롭·그라데이션 데코 금지.
+- **무드:** 전문적이고 깔끔한 쿨 팔레트에 옐로우 키컬러 한 점. 진지하지만 친근한 사내 도구.
+- **헤더:** 스크롤 전 투명 → 스크롤 후 `bg-white/70 backdrop-blur-xl` frosted glass 고정.
 
 ## Shape (핵심 규칙)
 
@@ -44,37 +44,46 @@
 
 | 토큰 | Hex | 용도 |
 |---|---|---|
-| `--color-bg` | `#F5F5F3` | 페이지 배경 |
-| `--color-surface` | `#FFFFFF` | 카드 |
-| `--color-surface-warm` | `#F7F7F5` | 따뜻한 면 |
-| `--color-board` / `--color-board-2` | `#111111` / `#242424` | 잉크 밴드(헤더/풋터/다크) / 활성 탭 면 |
-| `--color-ink` / `--color-ink-2` | `#111111` / `#454545` | 본문 / 보조 텍스트 |
-| `--color-muted` | `#8A8A8A` | 캡션/메타 **한정** (본문 대비 미달 — 본문 사용 금지) |
-| `--color-line` | `#E3E3E0` | 헤어라인 보더 |
-| `--color-cream` / `--color-cream-2` | `#F5F5F3` / `#9A9A9A` | 다크 위 텍스트 / 다크 위 보조 |
-| `--color-accent` | `#E2C04C` | 키컬러 (유일한 액센트) |
-| `--color-accent-deep` | `#C2A02E` | 키컬러 딥 |
-| `--color-accent-soft` | `#FAF4D9` | 키컬러 연한 면 |
-| `--color-accent-text` | `#997400` | 라이트 위 옐로우 텍스트 |
-| `--color-highlight` | `#F0E0A0` | 헤드라인 형광펜 |
-| `--color-down` / `--color-down-soft` | `#767676` / `#F1F1EF` | '별로다' 그레이 |
+| `--color-bg` | `#f3f6fb` | 페이지 배경 (cool blue-tint) |
+| `--color-surface` | `#ffffff` | 카드 배경 |
+| `--color-surface-warm` | `#eaf0f8` | 섹션 구분용 cool tint |
+| `--color-board` / `--color-board-2` | `#111720` / `#1a2333` | 다크 카드 (cool deep navy-black) / 활성 탭 면 |
+| `--color-ink` / `--color-ink-2` | `#111720` / `#455060` | 본문 / 보조 텍스트 (cool) |
+| `--color-muted` | `#7e8fa0` | 캡션/메타 **한정** (본문 대비 미달 — 본문 사용 금지) |
+| `--color-line` | `#d8e0ea` | 헤어라인 (cool blue-grey) |
+| `--color-cream` / `--color-cream-2` | `#dde5f0` / `#8fa4bc` | 다크 위 텍스트 / 다크 위 보조 |
+| `--color-accent` | `#e2c04c` | 키컬러 (유일한 액센트) |
+| `--color-accent-deep` | `#c2a02e` | 키컬러 딥 |
+| `--color-accent-soft` | `#faf3d6` | 키컬러 연한 면 |
+| `--color-accent-text` | `#836000` | 라이트 위 옐로우 텍스트 |
+| `--color-highlight` | `#eedfa0` | 헤드라인 형광펜 (코스 카테고리 레이블) |
+| `--color-down` / `--color-down-soft` | `#6e8094` / `#e4eaf3` | 비활성/보조 버튼 그레이 |
 
-- **테마: 라이트 단일 확정.** 다크모드 토글 제거(`next-themes` 미사용).
-- **하드코딩 금지:** `#C9C9C6`, `#B5B5B2` 등 토큰 밖 그레이는 토큰으로 흡수할 것.
+- **테마: 라이트 단일 확정.** 다크모드 없음(`next-themes` 미사용).
+- **하드코딩 금지:** 토큰 밖 그레이(`#B5B5B2` 등)는 토큰으로 흡수할 것.
 
 ## Spacing & Layout
 
 - **base unit:** 4px 계열. 밀도: comfortable(식단은 dense-but-readable).
 - **콘텐츠 컨테이너:** `min(880px, calc(100% - 40px))` (좌우 20px 거터 고정).
-- **홈 그리드:** 데스크톱 `1fr 300px` gap 24 → 920px 미만 1컬럼 스택. 우측 컬럼은 보드 높이에 stretch.
-- **헤딩 반응형:** 히어로 27px → 560px 미만 22px.
-- **그림자:** `--shadow-flat: 0 1px 2px rgba(0,0,0,.05)` 하나만.
+- **홈 그리드:** 데스크톱 `1fr 300px` gap 24 → 920px 미만 1컬럼 스택.
+- **헤딩 반응형:** 히어로 22px → 640px 미만 18px.
+- **최소 뷰포트:** `min-width: 360px`. 360px 미만에서는 `transform: scale(100vw / 360px)` 비율 유지 축소.
+- **그림자 (elevation — border 대체):**
+  - `--shadow-flat: 0 1px 2px rgba(0,0,0,.05)` — 미세 구분
+  - `--shadow-card: 0 1px 3px rgba(0,0,0,.06), 0 4px 20px rgba(0,0,0,.05)` — 카드 기본
+  - `--shadow-card-hover: 0 2px 6px rgba(0,0,0,.08), 0 8px 28px rgba(0,0,0,.07)` — 카드 호버
+- **border 사용 금지:** 카드 경계는 그림자로만 표현. `border` 클래스 추가 전 DESIGN.md 확인 필수.
 
 ## Motion
 
-- **방향:** minimal-functional — 이해를 돕는 전환만. 식단/사이트 크롬은 정적.
-- 예외: 게임 3종(사다리/슬롯/풍선)은 expressive 연출 허용(결과 선계산, 연출만 재생). 상세는 디자인 문서 §모션 스펙.
-- `prefers-reduced-motion` 시 결과 즉시 표시.
+- **방향:** minimal-functional — 이해를 돕는 전환만.
+- **구현된 키프레임** (`src/app/globals.css`):
+  - `fadeUp` — `opacity: 0 + translateY(6px)` → 정상. 0.28s ease. CourseRow 스태거(`animationDelay: index * 70ms`), HeroStatus 아이콘/텍스트.
+  - `fadeIn` — opacity만. 0.3s ease.
+  - `softPulse` — opacity 1↔0.55 반복 (2.4s). HeroStatus 운영 중 `Utensils` 아이콘.
+- **스태거 패턴:** `index * 70ms` delay — 목록 항목이 순차 등장하는 효과.
+- `prefers-reduced-motion` 대응 필요 (미구현 — 향후 추가).
 
 ## Iconography
 
@@ -103,5 +112,11 @@
 
 | Date | Decision | Rationale |
 |------|----------|-----------|
-| 2026-06-05 | 비스트로 테라코타(B안) + 풀 스퀘어 + 옐로우 단일 키컬러 + Pretendard 단일 + 라이트 단일 | `docs/design/2026-06-05-phase1-design.md` (D2/D3/D5) |
-| 2026-06-05 | DESIGN.md를 SSOT로 신설(/design-consultation) | 기존 phase1 디자인 문서 + globals.css 토큰 정리, a11y 규칙 명문화 |
+| 2026-06-05 | DESIGN.md를 SSOT로 신설 | globals.css 토큰 정리, a11y 규칙 명문화 |
+| 2026-06-05 | 풀 스퀘어 + 옐로우 단일 키컬러 + Pretendard 단일 + 라이트 단일 | 사내 유틸리티 무드, 다크모드 미지원 확정 |
+| 2026-06-06 | 쿨 팔레트로 전환 (bg `#f3f6fb`, ink `#111720`) | Toss 참고 — 웜톤 대비 전문적이고 쿨한 느낌 |
+| 2026-06-06 | border 전면 제거 → shadow-only elevation | `--shadow-card`/`--shadow-card-hover` 두 단계로 깊이 표현 |
+| 2026-06-06 | 투명 헤더 → scroll frosted glass | 메뉴 컨텐츠가 눈에 잘 띄도록, 헤더 강조 최소화 |
+| 2026-06-06 | 햄버거 메뉴 (640px 이하) | 좁은 뷰포트에서 nav 링크 풀스크린 드롭다운 |
+| 2026-06-06 | HeroStatus 동적 헤드라인 | 시각·요일·메뉴 유무 기반 6개 베리에이션, `softPulse` 운영 중 표시 |
+| 2026-06-06 | 코스 카테고리 레이블 형광펜 효과 | `linear-gradient(transparent 40%, --color-highlight 40%)` |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -14,7 +14,7 @@
 
 ## Aesthetic Direction
 
-- **방향:** Toss 톤앤매너 참고 — 쿨 블루틴트 배경 + near-black 잉크 + shadow-only elevation. 경계선 없음.
+- **방향:** 쿨 블루틴트 배경 + near-black 잉크 + shadow-only elevation. 경계선 없음.
 - **데코레이션 레벨:** minimal — 타이포와 여백이 일한다. 그림자로 깊이 표현. 장식 블롭·그라데이션 데코 금지.
 - **무드:** 전문적이고 깔끔한 쿨 팔레트에 옐로우 키컬러 한 점. 진지하지만 친근한 사내 도구.
 - **헤더:** 스크롤 전 투명 → 스크롤 후 `bg-white/70 backdrop-blur-xl` frosted glass 고정.
@@ -114,7 +114,7 @@
 |------|----------|-----------|
 | 2026-06-05 | DESIGN.md를 SSOT로 신설 | globals.css 토큰 정리, a11y 규칙 명문화 |
 | 2026-06-05 | 풀 스퀘어 + 옐로우 단일 키컬러 + Pretendard 단일 + 라이트 단일 | 사내 유틸리티 무드, 다크모드 미지원 확정 |
-| 2026-06-06 | 쿨 팔레트로 전환 (bg `#f3f6fb`, ink `#111720`) | Toss 참고 — 웜톤 대비 전문적이고 쿨한 느낌 |
+| 2026-06-06 | 쿨 팔레트로 전환 (bg `#f3f6fb`, ink `#111720`) | 웜톤 대비 전문적이고 쿨한 느낌 |
 | 2026-06-06 | border 전면 제거 → shadow-only elevation | `--shadow-card`/`--shadow-card-hover` 두 단계로 깊이 표현 |
 | 2026-06-06 | 투명 헤더 → scroll frosted glass | 메뉴 컨텐츠가 눈에 잘 띄도록, 헤더 강조 최소화 |
 | 2026-06-06 | 햄버거 메뉴 (640px 이하) | 좁은 뷰포트에서 nav 링크 풀스크린 드롭다운 |

--- a/README.md
+++ b/README.md
@@ -1,145 +1,147 @@
-# MegaBobs 🍽️
+# MegaBobs
 
-메가존 구내식당 식단표를 확인하는 웹 애플리케이션입니다. 현재 **단순 식단 조회**에서 **"오늘 점심, 뭐 먹을지 정해주는 점심 허브"** 로 확장하는 Phase 1 개편을 진행 중입니다.
+메가존 직원을 위한 구내식당 메뉴 뷰어입니다. 날짜별 식단 조회, Slack 봇 연동, 실시간 운영 상태 표시를 제공합니다.
 
 ---
 
-## 🚧 Phase 1 개편 (진행 중)
+## 주요 기능
 
-### 무엇을 개편하나
+- **날짜별 메뉴 조회** — 주간 캘린더로 날짜를 선택해 코스1 · 코스2 · 테이크아웃 메뉴 확인
+- **Slack 봇** — `/밥` 슬래시 커맨드로 오늘 · 내일 · 모레 · 글피 식단 조회
+- **반응형 햄버거 메뉴** — 640px 이하에서 풀스크린 드롭다운 메뉴 전환
+- **ISR 캐싱** — 6시간 재검증 + 매일 19:30 강제 revalidate + 15:00 캐시 워밍
 
-| 영역 | 현재 | 개편 후 |
+---
+
+## 기술 스택
+
+| 분류 | 기술 |
+|---|---|
+| 프레임워크 | Next.js 15 (App Router, Turbopack) |
+| UI | React 19, Tailwind CSS v4, Lucide React |
+| 상태 관리 | Zustand |
+| 데이터베이스 | Supabase (PostgreSQL) |
+| 날짜 처리 | dayjs (`Asia/Seoul` timezone) |
+| 배포 | Vercel |
+| 테스트 | Vitest, Testing Library |
+| 포맷 | ESLint, Prettier (+ `prettier-plugin-tailwindcss`) |
+
+---
+
+## 디자인 시스템
+
+자세한 토큰 · 타이포 · 컬러 · 간격 규칙은 [DESIGN.md](DESIGN.md)를 참고하세요.
+
+| 토큰 | 값 | 용도 |
 |---|---|---|
-| **정체성** | 식단표 뷰어 | 점심 의사결정 허브 (식단 + 투표 + 게임 + 맛집 + 콘텐츠) |
-| **비주얼** | 블루 톤 · 둥근 모서리 · 375px 모바일 | 푸드 웜톤 리브랜딩 · 각진 에디토리얼 무드 · 반응형 880px |
-| **상호작용** | 메뉴 조회만 | 코스별 투표, 점심 내기 게임, 맛집 탐색, 자동 발행 블로그 |
+| `--color-bg` | `#f3f6fb` | 페이지 배경 (cool blue-tint) |
+| `--color-surface` | `#ffffff` | 카드 배경 |
+| `--color-ink` | `#111720` | 본문 텍스트 |
+| `--color-accent` | `#e2c04c` | 브랜드 키컬러 |
+| `--shadow-card` | `0 1px 3px … 0 4px 20px …` | 카드 elevation (border 없음) |
 
-### 어떻게 개편하나
-
-- **🎨 푸드 웜톤 리브랜딩** — 뉴트럴 모노 베이스 + **단일 옐로우 키컬러(`#E2C04C`)**. 각진 모서리(radius 2~6px, pill 제거), 플랫 헤어라인, UI 이모지 제거(세리프 넘버링·이니셜·타이포 글리프로 대체). 디스플레이는 Noto Serif KR, 본문은 Pretendard.
-- **🗳️ 코스 투표** — 식단 보드에서 코스별 "맛있다 / 별로다" 투표 + 결과 막대. 다음 날 블로그 자동 정리에 활용.
-- **🎮 점심 내기 게임 3종** — 사다리 / 슬롯 / 풍선. 결과는 시작 전 미리 계산하고 연출만 재생(조작 불가). 슬랙 공유 + OG 이미지.
-- **📍 주변 맛집** — 카테고리·가격 필터, 카드형 목록 + 상세(메뉴·영업시간·꿀팁). 진입/상세 조회 계측.
-- **📰 블로그 + 소식** — 투표 결과 기반 데일리 리포트 자동 발행, 운영자 리뷰, 외부 소식 큐레이션 (AdSense "얇은 콘텐츠" 방지 구조).
-- **📱 반응형** — 데스크톱 2컬럼 / 모바일 1컬럼(다크 밴드 헤더 + 풀스크린 드로어 + 바텀시트), 터치 타겟 ≥44px, `prefers-reduced-motion` 대응.
-
-### 📐 기획·디자인 문서
-
-- **디자인 문서 (SSOT)**: [`docs/design/2026-06-05-phase1-design.md`](docs/design/2026-06-05-phase1-design.md)
-- **HTML 목업**: [`docs/design/mockups/`](docs/design/mockups/)
-- **Figma**: https://www.figma.com/design/Db40M9n99faf18mk211nM4
+- **경계선 없음** — 카드 구분은 그림자(`--shadow-card`)만 사용
+- **애니메이션** — `fadeUp`, `fadeIn`, `softPulse` keyframe (globals.css)
+- **반응형** — 데스크톱 2컬럼 (`1fr 300px`), 920px 이하 단일 컬럼
 
 ---
 
-## ✨ 주요 기능 (현재)
+## 시작하기
 
-- 📅 **날짜별 메뉴 조회**: 원하는 날짜의 식단을 확인할 수 있습니다
-- 🍝 **다양한 코스 메뉴**: 코스1, 코스2, 테이크아웃 메뉴를 선택할 수 있습니다
-- 💬 **Slack 봇 연동**: 슬래시 커맨드(오늘/내일/모레/글피)로 식단 조회
-- 📱 **모바일 최적화**: 반응형 디자인으로 모든 디바이스에서 사용 가능합니다
-- ⚡ **빠른 로딩**: ISR 캐싱과 캐시 워밍으로 최적화된 성능을 제공합니다
+### 환경 변수
 
-## 🛠️ 기술 스택
+`.env.local` 파일을 생성하고 아래 값을 채워주세요:
 
-### Frontend
-
-- **Next.js 15** (App Router) - React 프레임워크
-- **React 19** - UI 라이브러리
-- **TypeScript** - 타입 안전성
-- **Tailwind CSS 4** - 스타일링 (커스텀 테마 토큰)
-- **Zustand** - 클라이언트 상태 관리 (menu / date 스토어)
-- **TanStack Query** - 서버 상태 관리
-- **next-themes** - 다크모드, **react-hot-toast** - 토스트, **dayjs** - 날짜(Asia/Seoul)
-
-### Backend & Database
-
-- **Supabase** - 백엔드 서비스 및 PostgreSQL 데이터베이스
-- **MCP 서버** - Streamable HTTP 기반 (`pnpm mcp`)
-- **Vercel** - 배포, **Zod** - 스키마 검증
-
-### Development Tools
-
-- **ESLint** / **Prettier** - 코드 품질·포맷팅
-- **pnpm** - 패키지 매니저
-
-## 🚀 시작하기
-
-### 필수 조건
-
-- Node.js 18.17 이상
-- pnpm (권장) 또는 npm/yarn
+```
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+REVALIDATE_SECRET=
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+SLACK_SIGNING_SECRET=
+MENU_API_KEY=
+```
 
 ### 설치 및 실행
 
-1. **저장소 클론**
+```bash
+pnpm install
+pnpm dev        # http://localhost:3000
+```
 
-   ```bash
-   git clone https://github.com/hong-soohyuk/mega-bobs.git
-   cd mega-bobs
-   ```
-
-2. **의존성 설치**
-
-   ```bash
-   pnpm install
-   ```
-
-3. **환경 변수 설정**
-
-   ```bash
-   cp .env.example .env.local
-   ```
-
-   `.env.local` 파일에 다음 환경 변수를 설정하세요:
-
-   ```
-   NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
-   NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
-   SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
-   REVALIDATE_SECRET=your_revalidate_secret
-   NEXT_PUBLIC_SITE_URL=http://localhost:3000
-   ```
-
-4. **개발 서버 실행**
-
-   ```bash
-   pnpm dev
-   ```
-
-5. **브라우저에서 확인**
-   [http://localhost:3000](http://localhost:3000)에서 앱을 확인할 수 있습니다.
-
-## 📝 사용 가능한 스크립트
+### 스크립트
 
 ```bash
 pnpm dev            # 개발 서버 (Turbopack)
 pnpm build          # 프로덕션 빌드
 pnpm start          # 프로덕션 서버
-pnpm lint           # 린트 검사
-pnpm lint:fix       # 린트 자동 수정
-pnpm format         # 코드 포맷팅
-pnpm format:check   # 포맷 검사
+pnpm lint           # ESLint 검사
+pnpm lint:fix       # ESLint 자동 수정
+pnpm format         # Prettier 포맷
+pnpm format:check   # Prettier 검사
+pnpm test           # Vitest 단위 테스트
 pnpm mcp            # MCP 서버 실행
 ```
 
-## 📁 프로젝트 구조
+---
+
+## 아키텍처
+
+### 데이터 흐름
+
+```
+Supabase daily_menu
+  → page.tsx (서버 fetch, ISR 6h)
+  → MenuBoard (client)
+  → useDateStore (Zustand)
+  → DayBar / CourseRow
+```
+
+### 주요 디렉토리
 
 ```
 src/
-├── app/                  # Next.js App Router (페이지 + API 라우트)
-│   ├── api/             # menu / slack / revalidate / mcp 라우트
-│   ├── layout.tsx       # 루트 레이아웃
-│   └── page.tsx         # 홈 (ISR 6h, 서버 fetch)
-├── components/          # React 컴포넌트 (layout/ + 피처 컴포넌트)
-├── lib/                 # supabase-server.ts, api/getMenu.ts, utils.ts, dayjs.ts
-├── store/               # Zustand 스토어 (useMenuStore, useDateStore)
-├── types/               # TypeScript 타입 (MenuType, MenuCategory, ...)
-└── constants/           # 메뉴 카테고리, 식사 타입, Slack 커맨드 상수
+├── app/
+│   ├── api/
+│   │   ├── menu/         # GET ?start=&end= — 날짜 범위 메뉴 조회
+│   │   ├── slack/        # POST — 슬래시 커맨드, GET warm — 캐시 워밍
+│   │   └── revalidate/   # GET ?secret= — ISR 강제 재검증
+│   ├── layout.tsx
+│   └── page.tsx          # 홈 (ISR, HeroStatus 렌더)
+├── components/
+│   ├── @shared/          # SiteHeader (frosted glass + 햄버거), SiteFooter
+│   ├── board/            # MenuBoard, DayBar, CourseRow, BoardEmpty
+│   └── home/             # HeroStatus, HomeSide, HeroDate
+├── lib/
+│   ├── menu-policy.ts    # CAFETERIA 운영 시각 config (단일 소스)
+│   ├── supabase-server.ts
+│   ├── api/getMenu.ts
+│   ├── dayjs.ts          # Asia/Seoul 설정
+│   └── utils.ts
+├── store/
+│   └── useDateStore.ts   # today, selectedDate, currentWeek, 주 이동
+├── types/                # MenuType, MenuCategory, MealType, MenuItemType
+└── constants/            # 메뉴 카테고리, 식사 타입, Slack 커맨드, 사이트 링크
 ```
 
-## 🤖 Claude 스킬
+### 운영 시각 설정
 
-프로젝트 작업을 돕는 Claude 스킬/커맨드가 [`.claude/`](.claude/) 에 있습니다.
+구내식당 운영 시간은 `src/lib/menu-policy.ts`의 `CAFETERIA` 객체 하나에서 관리합니다. 여기만 수정하면 HeroStatus · Slack 봇 · 모든 레이블에 자동 반영됩니다.
 
-- **`/pr`** — diff 분석 후 구조화된 PR 본문(요약·Changes 테이블·Mermaid 시퀀스·테스트 계획)을 생성하고 `gh pr create` 실행
-- 스킬 목록과 작성 가이드는 [`.claude/skills/README.md`](.claude/skills/README.md) 참고
+```ts
+export const CAFETERIA = {
+  openHour: 11,
+  openMinute: 0,
+  closeHour: 13,
+  closeMinute: 15,
+} as const;
+```
+
+---
+
+## Claude 스킬
+
+프로젝트 작업을 돕는 Claude 스킬이 [`.claude/`](.claude/)에 있습니다.
+
+- **`/pr`** — diff 분석 후 PR 본문(요약 · Changes · 테스트 계획)을 생성하고 `gh pr create` 실행
+- 스킬 목록은 [`.claude/skills/README.md`](.claude/skills/README.md) 참고

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 
 @theme {
-  /* 디자인 시스템 — DESIGN.md / Toss-tone: near-black + clean white */
+  /* 디자인 시스템 — DESIGN.md / 쿨 팔레트: near-black + clean white + cool blue-tint */
   --color-bg: #f3f6fb; /* 페이지 배경 — cool blue-tint */
   --color-surface: #ffffff; /* 카드 */
   --color-surface-warm: #eaf0f8; /* 섹션 구분용 cool tint */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,25 +1,25 @@
 @import 'tailwindcss';
 
 @theme {
-  /* 디자인 시스템 — docs/design/2026-06-05-phase1-design.md §1 */
-  --color-bg: #f5f5f3; /* 페이지 배경 */
+  /* 디자인 시스템 — DESIGN.md / Toss-tone: near-black + clean white */
+  --color-bg: #f3f6fb; /* 페이지 배경 — cool blue-tint */
   --color-surface: #ffffff; /* 카드 */
-  --color-surface-warm: #f7f7f5;
-  --color-board: #111111; /* 잉크 — 헤더 밴드/다크 카드 */
-  --color-board-2: #242424; /* 활성 탭 면 */
-  --color-ink: #111111;
-  --color-ink-2: #454545;
-  --color-muted: #8a8a8a;
-  --color-line: #e3e3e0; /* 헤어라인 보더 */
-  --color-cream: #f5f5f3; /* 다크 위 텍스트 */
-  --color-cream-2: #9a9a9a;
-  --color-accent: #e2c04c; /* 키컬러 — 저채도 옐로우 */
+  --color-surface-warm: #eaf0f8; /* 섹션 구분용 cool tint */
+  --color-board: #111720; /* 다크 카드 — cool deep navy-black */
+  --color-board-2: #1a2333; /* 활성 탭 면 */
+  --color-ink: #111720; /* 본문 */
+  --color-ink-2: #455060; /* 보조 텍스트 — cool */
+  --color-muted: #7e8fa0; /* 캡션/메타 — cool */
+  --color-line: #d8e0ea; /* 헤어라인 — cool blue-grey */
+  --color-cream: #dde5f0; /* 다크 위 텍스트 */
+  --color-cream-2: #8fa4bc;
+  --color-accent: #e2c04c; /* 키컬러 — 옐로우 (브랜드 유지) */
   --color-accent-deep: #c2a02e;
-  --color-accent-soft: #faf4d9;
-  --color-accent-text: #997400; /* 라이트 배경 위 옐로우 텍스트 */
-  --color-highlight: #f0e0a0; /* 헤드라인 형광펜 */
-  --color-down: #767676;
-  --color-down-soft: #f1f1ef;
+  --color-accent-soft: #faf3d6;
+  --color-accent-text: #836000; /* 라이트 배경 위 */
+  --color-highlight: #eedfa0; /* 헤드라인 형광펜 */
+  --color-down: #6e8094;
+  --color-down-soft: #e4eaf3;
 
   --font-sans: var(--font-pretendard), -apple-system, sans-serif;
 
@@ -27,6 +27,23 @@
   --radius-none: 0;
 
   --shadow-flat: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.06), 0 4px 20px rgba(0, 0, 0, 0.05);
+  --shadow-card-hover: 0 2px 6px rgba(0, 0, 0, 0.08), 0 8px 28px rgba(0, 0, 0, 0.07);
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes softPulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.55; }
 }
 
 body {
@@ -34,4 +51,15 @@ body {
   color: var(--color-ink);
   font-family: var(--font-sans);
   word-break: keep-all;
+  min-width: 360px;
+}
+
+@media (max-width: 360px) {
+  html {
+    overflow-x: hidden;
+  }
+  body {
+    transform-origin: 0 0;
+    transform: scale(calc(100vw / 360px));
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import {ErrorBoundary, SiteFooter, SiteHeader} from '@/components/@shared';
 import MenuBoard from '@/components/board/MenuBoard';
 import HeroDate from '@/components/home/HeroDate';
+import HeroStatus from '@/components/home/HeroStatus';
 import HomeSide from '@/components/home/HomeSide';
 import getMenu from '@/lib/api/getMenu';
 import dayjs from '@/lib/dayjs';
@@ -19,16 +20,12 @@ export default async function Home() {
     <>
       <SiteHeader />
       <main className="mx-auto w-[min(880px,calc(100%-40px))] flex-1">
-        <section className="pt-8 pb-5">
-          <span className="inline-block bg-accent-soft px-2.5 py-1 text-xs font-extrabold tracking-wide text-accent-text">
-            <HeroDate /> · 과천 지식정보타운
-          </span>
-          <h1 className="mt-3 text-[27px] font-extrabold tracking-tight max-[560px]:text-[22px]">
-            오늘{' '}
-            <mark className="px-1 text-ink [background:linear-gradient(transparent_58%,var(--color-highlight)_58%)]">
-              점심
-            </mark>
-            , 정하셨나요?
+        <section className="pt-12 pb-6">
+          <p className="text-[11.5px] font-semibold tracking-[0.06em] text-muted uppercase">
+            <HeroDate />
+          </p>
+          <h1 className="mt-3 text-[22px] font-extrabold tracking-[-0.02em] text-ink max-[560px]:text-[18px]">
+            <HeroStatus menus={menus} />
           </h1>
         </section>
         <ErrorBoundary>

--- a/src/components/@shared/SiteFooter.tsx
+++ b/src/components/@shared/SiteFooter.tsx
@@ -3,16 +3,21 @@ import Link from 'next/link';
 import {FOOTER_LINKS} from '@/constants/site';
 
 const SiteFooter = () => (
-  <footer className="mt-16 bg-board text-cream-2">
-    <div className="mx-auto flex w-[min(880px,calc(100%-40px))] flex-wrap items-center justify-between gap-x-4 gap-y-1 py-3.5 text-[11.5px]">
-      <span className="font-extrabold text-cream">MegaBobs</span>
-      <div className="flex items-center gap-4">
-        {FOOTER_LINKS.map((l) => (
-          <Link key={l.label} href={l.href} className="font-bold text-cream">
-            {l.label}
-          </Link>
-        ))}
-        <span className="text-[#6E6E6E]">© 2026 megabobs</span>
+  <footer className="mt-16">
+    <div className="mx-auto w-[min(880px,calc(100%-40px))] py-6">
+      <div className="flex items-center justify-between gap-x-6 gap-y-3 max-[560px]:flex-col max-[560px]:items-center">
+        <div className="flex items-center gap-5 max-[560px]:flex-col max-[560px]:items-center max-[560px]:gap-1">
+          <span className="text-[13px] font-extrabold text-ink">MegaBobs</span>
+          <p className="text-[12px] text-muted">메가존 임직원을 위한 구내식당 메뉴 서비스</p>
+        </div>
+        <div className="flex items-center gap-5">
+          {FOOTER_LINKS.map((l) => (
+            <Link key={l.label} href={l.href} className="text-[12px] font-medium text-muted hover:text-ink-2 max-[560px]:hidden">
+              {l.label}
+            </Link>
+          ))}
+          <span className="text-[12px] text-muted">© 2026 megabobs</span>
+        </div>
       </div>
     </div>
   </footer>

--- a/src/components/@shared/SiteHeader.tsx
+++ b/src/components/@shared/SiteHeader.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import {Bell} from 'lucide-react';
+import {Bell, Menu, X} from 'lucide-react';
 import Link from 'next/link';
 import {usePathname} from 'next/navigation';
+import {useEffect, useState} from 'react';
 
 import noticeData from '@/../data/notices.json';
 import {NAV_ITEMS} from '@/constants/site';
@@ -13,7 +14,6 @@ import type {NoticeData} from '@/types/notice';
 
 const {notices} = noticeData as NoticeData;
 
-/** 발행 후 일주일 이내 공지가 하나라도 있으면 NEW */
 const hasRecentNotice = () =>
   notices.some((n) => dayjs().tz().diff(dayjs.tz(n.publishedAt), 'day') < 7);
 
@@ -21,14 +21,115 @@ const SiteHeader = () => {
   const pathname = usePathname();
   const mounted = useHasMounted();
   const showNoticeDot = mounted && hasRecentNotice();
+  const [scrolled, setScrolled] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 8);
+    window.addEventListener('scroll', onScroll, {passive: true});
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    document.body.style.overflow = menuOpen ? 'hidden' : '';
+    return () => {document.body.style.overflow = '';};
+  }, [menuOpen]);
 
   return (
-    <header className="bg-board">
-      <div className="mx-auto flex h-16 w-[min(880px,calc(100%-40px))] items-center gap-7">
-        <Link href="/" className="text-xl font-extrabold tracking-tight text-cream">
-          MegaBobs
-        </Link>
-        <nav className="flex flex-1 gap-0.5 overflow-x-auto whitespace-nowrap">
+    <>
+      <header
+        className={cn(
+          'sticky top-0 z-50 transition-all duration-300',
+          scrolled || menuOpen ? 'bg-white/70 backdrop-blur-xl' : 'bg-transparent'
+        )}
+      >
+        <div className="mx-auto flex h-14 w-[min(880px,calc(100%-40px))] items-center gap-7">
+          <Link href="/" className="text-[17px] font-extrabold tracking-tight text-ink">
+            MegaBobs
+          </Link>
+
+          {/* 데스크톱 nav */}
+          <nav className="flex flex-1 gap-0.5 overflow-x-auto whitespace-nowrap max-[640px]:hidden">
+            {NAV_ITEMS.map((item) => {
+              const active = pathname === item.href;
+              return (
+                <Link
+                  key={item.href}
+                  href={item.disabled ? '#' : item.href}
+                  aria-disabled={item.disabled}
+                  className={cn(
+                    'flex items-center gap-1.5 px-3 py-2 text-[13.5px] font-semibold',
+                    active
+                      ? 'text-ink shadow-[inset_0_-2px_0_var(--color-accent)]'
+                      : 'text-muted hover:text-ink-2',
+                    item.disabled && 'cursor-default opacity-50'
+                  )}
+                >
+                  {item.label}
+                  {item.disabled && (
+                    <span className="bg-down-soft text-down px-1 py-px text-[9px] font-bold">
+                      준비중
+                    </span>
+                  )}
+                </Link>
+              );
+            })}
+          </nav>
+
+          {/* 데스크톱 벨 */}
+          <Link
+            href="/notice"
+            title="공지사항"
+            aria-label="공지사항"
+            className="relative flex size-9 items-center justify-center text-ink-2 max-[640px]:hidden"
+          >
+            <Bell size={17} strokeWidth={2.2} />
+            {showNoticeDot && (
+              <span aria-hidden className="absolute top-[7px] right-[6px] size-1.5 bg-accent" />
+            )}
+          </Link>
+
+          {/* 모바일 우측 */}
+          <div className="ml-auto flex items-center gap-1 min-[641px]:hidden">
+            <Link
+              href="/notice"
+              title="공지사항"
+              aria-label="공지사항"
+              className="relative flex size-9 items-center justify-center text-ink-2"
+            >
+              <Bell size={17} strokeWidth={2.2} />
+              {showNoticeDot && (
+                <span aria-hidden className="absolute top-[7px] right-[6px] size-1.5 bg-accent" />
+              )}
+            </Link>
+            <button
+              type="button"
+              aria-label={menuOpen ? '메뉴 닫기' : '메뉴 열기'}
+              onClick={() => setMenuOpen((v) => !v)}
+              className="flex size-9 items-center justify-center text-ink-2"
+            >
+              {menuOpen ? <X size={20} strokeWidth={2} /> : <Menu size={20} strokeWidth={2} />}
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {/* 모바일 메뉴 — header 밖 fixed, stacking context 영향 없음 */}
+      <div
+        className={cn(
+          'fixed inset-0 top-14 z-40 min-[641px]:hidden',
+          'bg-[var(--color-bg)]',
+          'transition-all duration-200 ease-in-out',
+          menuOpen
+            ? 'opacity-100 translate-y-0 pointer-events-auto'
+            : 'opacity-0 -translate-y-2 pointer-events-none'
+        )}
+      >
+        <nav className="mx-auto w-[min(880px,calc(100%-40px))] flex flex-col pb-4 pt-1">
           {NAV_ITEMS.map((item) => {
             const active = pathname === item.href;
             return (
@@ -36,17 +137,16 @@ const SiteHeader = () => {
                 key={item.href}
                 href={item.disabled ? '#' : item.href}
                 aria-disabled={item.disabled}
+                onClick={() => setMenuOpen(false)}
                 className={cn(
-                  'flex items-center gap-1.5 px-3 py-2 text-sm font-semibold',
-                  active
-                    ? 'bg-board-2 text-white shadow-[inset_0_-2px_0_var(--color-accent)]'
-                    : 'text-cream-2 hover:bg-board-2',
-                  item.disabled && 'cursor-default opacity-60'
+                  'flex items-center justify-between py-3.5 text-[15px] font-semibold border-b border-line/50',
+                  active ? 'text-ink' : 'text-ink-2',
+                  item.disabled && 'cursor-default opacity-40'
                 )}
               >
                 {item.label}
                 {item.disabled && (
-                  <span className="bg-board-2 px-1 py-px text-[9px] font-bold text-cream">
+                  <span className="bg-down-soft text-down px-1.5 py-0.5 text-[9px] font-bold">
                     준비중
                   </span>
                 )}
@@ -54,19 +154,8 @@ const SiteHeader = () => {
             );
           })}
         </nav>
-        <Link
-          href="/notice"
-          title="공지사항"
-          aria-label="공지사항"
-          className="relative flex size-9 items-center justify-center text-cream"
-        >
-          <Bell size={18} strokeWidth={2.4} />
-          {showNoticeDot && (
-            <span aria-hidden className="absolute top-[7px] right-[6px] size-1.5 bg-accent" />
-          )}
-        </Link>
       </div>
-    </header>
+    </>
   );
 };
 

--- a/src/components/board/BoardEmpty.tsx
+++ b/src/components/board/BoardEmpty.tsx
@@ -6,7 +6,7 @@ const COPY = {
   closed: {
     label: 'CLOSED',
     title: '구내식당이 쉬는 날이에요',
-    body: '그래도 점심은 먹어야죠 — 주변 맛집은 어때요?',
+    body: '',
   },
   comingUp: {
     label: 'COMING UP',
@@ -24,9 +24,11 @@ const BoardEmpty = ({variant}: BoardEmptyProps) => {
         {copy.label}
       </div>
       <h3 className="mt-3 text-[17px] font-extrabold">{copy.title}</h3>
-      <p className="text-muted mt-1.5 text-[13.5px] leading-relaxed">
-        {copy.body}
-      </p>
+      {copy.body && (
+        <p className="text-muted mt-1.5 text-[13.5px] leading-relaxed">
+          {copy.body}
+        </p>
+      )}
     </div>
   );
 };

--- a/src/components/board/CourseRow.tsx
+++ b/src/components/board/CourseRow.tsx
@@ -3,15 +3,22 @@ import {MenuType} from '@/types/menu';
 
 interface CourseRowProps {
   menu: MenuType;
+  index?: number;
 }
 
-const CourseRow = ({menu}: CourseRowProps) => {
+const CourseRow = ({menu, index = 0}: CourseRowProps) => {
   const total = menu.items.reduce((sum, item) => sum + (item.kcal ?? 0), 0);
 
   return (
-    <div className="border-line border-b px-6 py-5 last:border-b-0">
+    <div
+      className="border-line border-b px-6 py-5 last:border-b-0"
+      style={{animation: 'fadeUp 0.28s ease both', animationDelay: `${index * 70}ms`}}
+    >
       <div className="flex items-baseline gap-2.5">
-        <span className="text-accent-text text-[11px] font-extrabold tracking-wider">
+        <span
+          className="text-accent-text text-[11px] font-extrabold tracking-wider"
+          style={{background: 'linear-gradient(transparent 40%, var(--color-highlight) 40%)', paddingInline: '2px'}}
+        >
           {MenuCategoryLabel[menu.category].ko}
         </span>
         {total > 0 && (

--- a/src/components/board/DayBar.tsx
+++ b/src/components/board/DayBar.tsx
@@ -7,19 +7,26 @@ import {useDateStore} from '@/store/useDateStore';
 
 const DOW = ['일', '월', '화', '수', '목', '금', '토'];
 
-const chipBorder = (isSelected: boolean, isToday: boolean) => {
-  if (!isSelected) return 'border-line bg-surface';
-  return isToday ? 'border-accent bg-accent' : 'border-ink bg-ink';
+const chipBg = (isSelected: boolean, isToday: boolean) => {
+  if (!isSelected) return 'bg-transparent hover:bg-surface-warm';
+  return isToday ? 'bg-accent' : 'bg-ink';
 };
 
-const labelClass = (isSelected: boolean, isToday: boolean, isPast: boolean) => {
+const dowColor = (dow: number, isPast: boolean) => {
+  if (isPast) return 'text-[#B5B5B2]';
+  if (dow === 0) return 'text-red-500';
+  if (dow === 6) return 'text-blue-500';
+  return null;
+};
+
+const labelClass = (isSelected: boolean, isToday: boolean, isPast: boolean, dow: number) => {
   if (isSelected) return isToday ? 'text-ink/55' : 'text-white/60';
-  return isPast ? 'text-[#B5B5B2]' : 'text-muted';
+  return dowColor(dow, isPast) ?? 'text-muted';
 };
 
-const dateClass = (isSelected: boolean, isToday: boolean, isPast: boolean) => {
+const dateClass = (isSelected: boolean, isToday: boolean, isPast: boolean, dow: number) => {
   if (isSelected) return isToday ? 'text-ink' : 'text-white';
-  return isPast ? 'text-[#B5B5B2]' : 'text-ink';
+  return dowColor(dow, isPast) ?? 'text-ink';
 };
 
 interface DayChipProps {
@@ -42,24 +49,24 @@ const DayChip = ({day, today, selectedDate, onSelect, mounted}: DayChipProps) =>
       onClick={() => onSelect(day)}
       aria-pressed={isSelected}
       className={cn(
-        'flex flex-1 cursor-pointer flex-col items-center gap-0.5 border py-1.5',
-        chipBorder(isSelected, isToday)
+        'flex flex-1 cursor-pointer flex-col items-center gap-0.5 py-1.5 transition-colors duration-150',
+        chipBg(isSelected, isToday)
       )}
     >
       <span
         suppressHydrationWarning
         className={cn(
           'text-[10px] font-bold',
-          labelClass(isSelected, isToday, isPast)
+          labelClass(isSelected, isToday, isPast, day.day())
         )}
       >
-        {isToday ? '오늘' : DOW[day.day()]}
+        {DOW[day.day()]}
       </span>
       <span
         suppressHydrationWarning
         className={cn(
           'text-[13.5px] font-extrabold',
-          dateClass(isSelected, isToday, isPast)
+          dateClass(isSelected, isToday, isPast, day.day())
         )}
       >
         {day.date()}
@@ -85,7 +92,7 @@ const DayBar = () => {
         type="button"
         onClick={goToPrevWeek}
         aria-label="지난주 메뉴 보기"
-        className="border-line text-ink flex h-11 w-7 shrink-0 cursor-pointer items-center justify-center border"
+        className="text-muted hover:text-ink flex h-11 w-7 shrink-0 cursor-pointer items-center justify-center transition-transform duration-100 active:scale-75"
       >
         ‹
       </button>
@@ -105,7 +112,7 @@ const DayBar = () => {
         type="button"
         onClick={goToNextWeek}
         aria-label="다음 주 메뉴 보기"
-        className="border-line text-ink flex h-11 w-7 shrink-0 cursor-pointer items-center justify-center border"
+        className="text-muted hover:text-ink flex h-11 w-7 shrink-0 cursor-pointer items-center justify-center transition-transform duration-100 active:scale-75"
       >
         ›
       </button>

--- a/src/components/board/MenuBoard.tsx
+++ b/src/components/board/MenuBoard.tsx
@@ -1,9 +1,12 @@
 'use client';
 
+import {CalendarDays, MapPin} from 'lucide-react';
 import {useMemo} from 'react';
 
+import {cn} from '@/lib/utils';
+
 import {MENU_CATEGORIES} from '@/constants/menu';
-import {CAFETERIA, isNextWeek, isNextWeekPublished} from '@/lib/menu-policy';
+import {isNextWeek, isNextWeekPublished} from '@/lib/menu-policy';
 import {formatYYYYMMDD} from '@/lib/utils';
 import {useDateStore} from '@/store/useDateStore';
 import {MenuType} from '@/types/menu';
@@ -18,7 +21,7 @@ interface MenuBoardProps {
 }
 
 const MenuBoard = ({menus}: MenuBoardProps) => {
-  const {today, selectedDate} = useDateStore();
+  const {today, selectedDate, setSelectedDate} = useDateStore();
 
   const dayMenus = useMemo(() => {
     const key = formatYYYYMMDD(selectedDate);
@@ -35,16 +38,31 @@ const MenuBoard = ({menus}: MenuBoardProps) => {
       : 'closed';
 
   return (
-    <section className="bg-surface shadow-flat border-line flex flex-col border">
-      <div className="bg-accent text-ink flex items-center justify-between px-6 py-4">
-        <h2 className="text-base font-extrabold">메뉴</h2>
-        <span className="text-ink/60 text-xs font-bold">
-          메가존 구내식당 · {CAFETERIA.openLabel}
-        </span>
+    <section className="bg-surface flex flex-col shadow-[var(--shadow-card)]">
+      <div className="flex items-center justify-between px-6 py-4 border-b border-line">
+        <h2 className="flex items-center gap-2">
+          <span className="text-[14px] font-extrabold tracking-wide text-ink">메뉴</span>
+          <span className="flex items-center gap-1 text-[11px] font-medium text-muted">
+            <MapPin size={10} strokeWidth={2.5} />
+            메가존 구내식당
+          </span>
+        </h2>
+        <button
+          type="button"
+          onClick={() => setSelectedDate(today)}
+          aria-hidden={selectedDate.isSame(today, 'day')}
+          className={cn(
+            'flex items-center gap-1.5 border border-accent/50 bg-accent-soft px-3 py-1 text-[11px] font-bold text-accent-text transition-opacity hover:opacity-70',
+            selectedDate.isSame(today, 'day') ? 'invisible' : 'visible'
+          )}
+        >
+          <CalendarDays size={11} strokeWidth={2.5} />
+          오늘
+        </button>
       </div>
       <DayBar />
       {dayMenus.length > 0 ? (
-        dayMenus.map((menu) => <CourseRow key={menu.category} menu={menu} />)
+        dayMenus.map((menu, i) => <CourseRow key={menu.category} menu={menu} index={i} />)
       ) : (
         <BoardEmpty variant={emptyVariant} />
       )}

--- a/src/components/home/HeroStatus.tsx
+++ b/src/components/home/HeroStatus.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import {Clock, Moon, Sun, Utensils} from 'lucide-react';
+import {useEffect, useState} from 'react';
+
+import dayjs from '@/lib/dayjs';
+import {CAFETERIA_CLOSE_MIN, CAFETERIA_LABEL, CAFETERIA_OPEN_MIN} from '@/lib/menu-policy';
+import {formatYYYYMMDD} from '@/lib/utils';
+import {MenuType} from '@/types/menu';
+
+type Status = {icon: React.ElementType; text: string};
+
+const nextWorkdayKey = (from: dayjs.Dayjs): string => {
+  const dow = from.day();
+  const ahead = dow === 5 ? 3 : dow === 6 ? 2 : 1;
+  return formatYYYYMMDD(from.add(ahead, 'day'));
+};
+
+const getStatus = (menus: MenuType[], now: dayjs.Dayjs): Status => {
+  const dow = now.day();
+  const min = now.hour() * 60 + now.minute();
+  const hasMenu = (key: string) => menus.some((m) => m.date === key && m.items.length > 0);
+
+  if (dow === 0 || dow === 6) {
+    return hasMenu(nextWorkdayKey(now))
+      ? {icon: Sun, text: '주말이에요, 월요일에 만나요!'}
+      : {icon: Sun, text: '편안한 주말 되세요!'};
+  }
+
+  // 평일인데 오늘 메뉴 없음 → 공휴일
+  const todayKey = formatYYYYMMDD(now);
+  if (!hasMenu(todayKey)) {
+    const nwKey = nextWorkdayKey(now);
+    return hasMenu(nwKey)
+      ? {icon: Sun, text: '오늘은 공휴일이에요. 내일 만나요!'}
+      : {icon: Sun, text: '오늘은 공휴일이에요.'};
+  }
+
+  if (min < CAFETERIA_OPEN_MIN) return {icon: Clock, text: '잠시 후 운영 시작이에요.'};
+  if (min < CAFETERIA_CLOSE_MIN) return {icon: Utensils, text: `지금 운영 중이에요! ${CAFETERIA_LABEL}`};
+
+  if (dow === 5) {
+    return hasMenu(nextWorkdayKey(now))
+      ? {icon: Moon, text: '오늘 점심은 끝났어요. 월요일에 만나요!'}
+      : {icon: Sun, text: '즐거운 주말 되세요!'};
+  }
+
+  const tomorrowKey = formatYYYYMMDD(now.add(1, 'day'));
+  return hasMenu(tomorrowKey)
+    ? {icon: Moon, text: '오늘 점심은 끝났어요. 내일 만나요!'}
+    : {icon: Moon, text: '오늘 점심은 끝났어요.'};
+};
+
+const HeroStatus = ({menus}: {menus: MenuType[]}) => {
+  const [status, setStatus] = useState<Status>(() => getStatus(menus, dayjs().tz()));
+
+  useEffect(() => {
+    const update = () => setStatus(getStatus(menus, dayjs().tz()));
+    update();
+    const id = setInterval(update, 60_000);
+    return () => clearInterval(id);
+  }, [menus]);
+
+  const Icon = status.icon;
+  const isOperating = status.icon === Utensils;
+
+  return (
+    <span
+      key={status.text}
+      suppressHydrationWarning
+      className="inline-flex items-center gap-2"
+    >
+      <Icon
+        size={26}
+        strokeWidth={2}
+        className="shrink-0"
+        style={{
+          animation: isOperating
+            ? 'fadeUp 0.35s ease both, softPulse 2.4s ease-in-out 0.35s infinite'
+            : 'fadeUp 0.35s ease both',
+        }}
+      />
+      <span style={{animation: 'fadeUp 0.4s ease 0.08s both'}}>
+        {status.text}
+      </span>
+    </span>
+  );
+};
+
+export default HeroStatus;

--- a/src/components/home/HomeSide.tsx
+++ b/src/components/home/HomeSide.tsx
@@ -22,26 +22,20 @@ const EntryInner = ({no, label, desc, disabled}: {no: string; label: string; des
   </>
 );
 
-const ENTRY_CLASS = 'shadow-flat flex min-h-[62px] flex-1 items-center gap-3.5 border border-line bg-surface px-4';
+const ENTRY_CLASS = 'flex min-h-[62px] flex-1 items-center gap-3.5 bg-surface px-4 shadow-[var(--shadow-card)]';
 
 const HomeSide = () => (
   <aside className="flex flex-col gap-4">
-    <div className="relative overflow-hidden bg-board p-5 text-cream">
-      <span
-        aria-hidden
-        className="absolute right-3 -bottom-7 text-[110px] leading-none font-black text-cream opacity-10"
-      >
-        ?
-      </span>
-      <h3 className="text-lg font-extrabold">오늘 뭐 먹지?</h3>
-      <p className="mt-1.5 text-[13px] leading-relaxed text-cream-2">
+    <div className="bg-surface p-6 shadow-[var(--shadow-card)]">
+      <h3 className="text-[14px] font-bold text-ink-2">오늘 뭐 먹지?</h3>
+      <p className="mt-1.5 text-[12.5px] leading-relaxed text-muted">
         구내식당과 지정타 맛집 중에서
         <br />
         점심 메뉴를 골라드려요
       </p>
       <button
         disabled
-        className="relative mt-4 w-full cursor-default bg-accent py-3 text-[15px] font-extrabold text-ink disabled:opacity-60"
+        className="mt-4 w-full cursor-default bg-down-soft py-2.5 text-[12.5px] font-semibold text-muted disabled:opacity-60"
       >
         랜덤 추천 받기 (준비 중)
       </button>

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -27,5 +27,4 @@ export const HOME_ENTRIES: HomeEntry[] = [
 
 export const FOOTER_LINKS = [
   {label: '공지사항', href: '/notice'},
-  {label: '만든 사람들', href: '/notice#makers'},
 ] as const;

--- a/src/lib/menu-policy.ts
+++ b/src/lib/menu-policy.ts
@@ -1,11 +1,19 @@
 import dayjs from '@/lib/dayjs';
 import {getWeekDays} from '@/lib/utils';
 
-/** 구내식당 운영 시각 상수 — 마감 시각 파생의 단일 출처 */
+const pad = (n: number) => String(n).padStart(2, '0');
+
+/** 구내식당 운영 시각 config — 여기만 수정하면 전체 반영 */
 export const CAFETERIA = {
-  openLabel: '11:00 – 13:15',
+  openHour: 11,
+  openMinute: 0,
   closeHour: 13,
+  closeMinute: 15,
 } as const;
+
+export const CAFETERIA_OPEN_MIN = CAFETERIA.openHour * 60 + CAFETERIA.openMinute;
+export const CAFETERIA_CLOSE_MIN = CAFETERIA.closeHour * 60 + CAFETERIA.closeMinute;
+export const CAFETERIA_LABEL = `${pad(CAFETERIA.openHour)}:${pad(CAFETERIA.openMinute)} – ${pad(CAFETERIA.closeHour)}:${pad(CAFETERIA.closeMinute)}`;
 
 /** 월요일 시작 주의 첫날 — getWeekDays(로케일 비의존)와 동일 기준 */
 const startOfWeekMon = (d: dayjs.Dayjs) => getWeekDays(d)[0];

--- a/src/lib/useHasMounted.ts
+++ b/src/lib/useHasMounted.ts
@@ -1,14 +1,14 @@
 'use client';
 
-import {useEffect, useState} from 'react';
+import {useLayoutEffect, useState} from 'react';
 
 /**
  * 클라이언트 마운트 여부.
- * ISR 정적 HTML(생성 시점 '오늘')과 클라이언트의 실제 '오늘'이 어긋날 수 있는
- * 날짜 의존 UI를 마운트 후에만 확정해 하이드레이션 불일치/점프를 막는다.
+ * useLayoutEffect — 브라우저 페인트 전에 동기 실행되므로
+ * mounted=false 상태가 화면에 노출되지 않아 레이아웃 shift가 없다.
  */
 export const useHasMounted = () => {
   const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  useLayoutEffect(() => setMounted(true), []);
   return mounted;
 };


### PR DESCRIPTION
## 개요

> **한줄 요약**: 쿨 팔레트 디자인 파운데이션 구축 — HeroStatus 동적 헤드라인, frosted glass 헤더, 모바일 햄버거 메뉴 추가

디자인 전체를 웜톤에서 쿨 블루틴트 팔레트로 전환하고 UI 파운데이션을 정비했습니다.
경계선 없는 shadow-only elevation, CSS 애니메이션(`fadeUp`/`softPulse`), 360px 최솟값 대응 등 기반 토큰을 새로 정리하고,
구내식당 운영 상태를 시각·요일·메뉴 유무에 따라 실시간으로 보여주는 HeroStatus 컴포넌트를 추가했습니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **디자인 토큰** | `globals.css` | 쿨 팔레트 전환, shadow-card 토큰, `fadeUp`·`softPulse` 키프레임, 360px 최솟값 |
| **HeroStatus** | `HeroStatus.tsx` (신규), `page.tsx` | 시각·요일·메뉴 유무 기반 6개 상태 동적 헤드라인, 60초 자동 갱신 |
| **SiteHeader** | `SiteHeader.tsx` | 스크롤 frosted glass(`bg-white/70 backdrop-blur-xl`) + 640px 이하 햄버거 풀스크린 메뉴 |
| **메뉴 보드** | `MenuBoard.tsx`, `DayBar.tsx`, `CourseRow.tsx`, `BoardEmpty.tsx` | 오늘로 버튼, fadeUp 스태거, 카테고리 형광펜, DayBar border 제거 |
| **레이아웃** | `SiteFooter.tsx`, `HomeSide.tsx` | dark 배경 → 라이트 shadow-card, 장식 요소 정리 |
| **Lib/Config** | `menu-policy.ts`, `useHasMounted.ts`, `site.ts` | CAFETERIA 단일 소스 config, `useLayoutEffect` 전환 |
| **문서** | `README.md`, `DESIGN.md`, `skills/README.md` | 현행화 및 외부 브랜드 레퍼런스 제거 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 사용자
    participant 홈페이지 as page.tsx
    participant 히어로 as HeroStatus
    participant 헤더 as SiteHeader
    participant 보드 as MenuBoard

    사용자->>홈페이지: 진입
    홈페이지->>히어로: menus 전달
    히어로->>히어로: 시각·요일·메뉴 유무 판별
    히어로-->>사용자: 동적 헤드라인 표시 (60초 갱신)

    사용자->>헤더: 스크롤
    헤더-->>사용자: frosted glass 전환

    alt 640px 이하
        사용자->>헤더: 햄버거 클릭
        헤더-->>사용자: 풀스크린 메뉴 오픈
    end

    사용자->>보드: 날짜 선택
    보드-->>사용자: fadeUp 스태거 애니메이션으로 코스 표시
```

&nbsp;

## 주요 리뷰 요청사항

- `useLayoutEffect` 전환이 SSR 환경에서 경고 없이 동작하는지 확인 부탁드립니다 (`useHasMounted.ts`)
- DayBar 주말 요일색(일요일 `text-red-500`, 토요일 `text-blue-500`)을 Tailwind 유틸리티로 쓰는데, 디자인 토큰화 필요 여부 의견 부탁드립니다

&nbsp;

## 테스트 계획

- [ ] HeroStatus — 운영 전(11시 이전) / 운영 중(11~13:15) / 운영 후 각 텍스트·아이콘 확인
- [ ] 운영 중 Utensils 아이콘 `softPulse` 애니메이션 확인
- [ ] 헤더 스크롤 시 frosted glass 전환, 최상단 복귀 시 투명 복원 확인
- [ ] 640px 이하: 햄버거 열기/닫기, 링크 클릭 시 자동 닫힘, body 스크롤 잠금
- [ ] DayBar 다른 날 선택 시 오늘로 버튼 표시, 오늘 선택 시 숨김
- [ ] CourseRow fadeUp 스태거 (첫 행부터 70ms 간격 순차 등장)
- [ ] 360px 미만 뷰포트 scale 축소 레이아웃 확인
- [ ] `pnpm build` 에러 없음

---

> 🎭 **오늘의 커밋 시**
>
> 차갑게 식어버린 팔레트 🧊
> 따뜻한 테라코타는 어디 가고
> 쿨 블루틴트만 남았네
> 근데 솔직히... 더 맛있어 보여 🍽️

🤖 Generated with [Claude Code](https://claude.com/claude-code)