### PR TITLE
chore: [Claude 스킬] 프로젝트 스킬 5종 추가 + CLAUDE.md 전면 재정의

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -8,11 +8,11 @@ MegaBobs Phase 1 구현을 돕는 프로젝트 레벨 Claude 스킬 모음입니
 
 | 스킬 | 폴더 | 목적 | 발동 시점 |
 |---|---|---|---|
-| create-pr | `create-pr/` | diff 분석 → 구조화된 PR 본문(요약·Changes 테이블·Mermaid·테스트 계획) 생성 후 `gh pr create`. 슬래시 커맨드 [`/pr`](../commands/pr.md) 과 동일 절차 (✅ 작성 완료) | "PR 만들어줘" 등 PR 생성 요청 시 |
-| 디자인 시스템 가드 | `design-system-guard/` | Phase 1 디자인 토큰·컨벤션(각진 모서리, 단일 옐로우 키컬러 `#E2C04C`, UI 이모지 금지, Pretendard/Noto Serif KR)을 UI 구현 시 강제 | 컴포넌트·스타일 작성/리뷰 시 |
-| 컴포넌트 스캐폴딩 | `component-scaffold/` | 프로젝트 컨벤션(arrow fn + `export default`, 네이밍, import 순서, 300줄/80줄 제한)에 맞춰 새 컴포넌트·페이지 생성 | 새 컴포넌트/페이지 추가 시 |
-| API 라우트 패턴 | `api-route-pattern/` | Next.js Route Handler + Supabase + 인증/캐시 패턴을 따르는 새 API 엔드포인트 생성 | `src/app/api/*` 추가 시 |
-| Supabase 스키마 작업 | `supabase-schema/` | 투표·메뉴·맛집 등 테이블/마이그레이션과 타입·쿼리 레이어를 일관되게 작성 | 새 테이블/스키마 변경 시 |
+| `create-pr` | `create-pr/` | diff 분석 → 구조화된 PR 본문(요약·Changes 테이블·Mermaid·테스트 계획) 생성 후 `gh pr create` | "PR 만들어줘" 등 PR 생성 요청 시 |
+| `design-system-guard` | `design-system-guard/` | DESIGN.md 토큰·규칙 위반(border, rounded, 하드코딩 컬러, 이모지 등) 검출 및 수정 제안, 접근성 체크 | 컴포넌트·스타일 작성/리뷰 시 |
+| `component-scaffold` | `component-scaffold/` | 프로젝트 컨벤션(arrow fn, 네이밍, import 순서, 300/80줄 제한)에 맞춰 새 컴포넌트·페이지·훅 생성 | 새 컴포넌트/페이지/훅 추가 시 |
+| `api-route-pattern` | `api-route-pattern/` | Next.js Route Handler + Supabase + 인증/캐시 패턴으로 새 API 엔드포인트 생성 | `src/app/api/*` 추가 시 |
+| `supabase-schema` | `supabase-schema/` | 테이블 SQL·RLS 정책·TypeScript 타입·쿼리 함수를 일관되게 작성 | 새 테이블/스키마 변경 시 |
 
 ## 작성 가이드
 

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -13,6 +13,7 @@ MegaBobs Phase 1 구현을 돕는 프로젝트 레벨 Claude 스킬 모음입니
 | `component-scaffold` | `component-scaffold/` | 프로젝트 컨벤션(arrow fn, 네이밍, import 순서, 300/80줄 제한)에 맞춰 새 컴포넌트·페이지·훅 생성 | 새 컴포넌트/페이지/훅 추가 시 |
 | `api-route-pattern` | `api-route-pattern/` | Next.js Route Handler + Supabase + 인증/캐시 패턴으로 새 API 엔드포인트 생성 | `src/app/api/*` 추가 시 |
 | `supabase-schema` | `supabase-schema/` | 테이블 SQL·RLS 정책·TypeScript 타입·쿼리 함수를 일관되게 작성 | 새 테이블/스키마 변경 시 |
+| `start-ticket` | `start-ticket/` | Notion 티켓 조회 → 작업 계획 기입 → dev 기준 브랜치 생성까지 작업 착수 절차 전체 처리 | "작업 시작", "MEGA-XX 시작", 티켓 기반 작업 착수 시 |
 
 ## 작성 가이드
 

--- a/.claude/skills/api-route-pattern/SKILL.md
+++ b/.claude/skills/api-route-pattern/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: api-route-pattern
+description: Next.js App Router Route Handler + Supabase + 인증/캐시 패턴으로 새 API 엔드포인트 생성. "API 만들어", "/api/* 추가", "엔드포인트 추가" 요청 시 발동.
+---
+
+# API Route Pattern
+
+`src/app/api/` 하위에 새 Route Handler를 만들 때 이 절차를 따른다.
+
+## STEP 1: 기존 라우트 참조
+
+`src/app/api/` 를 확인해 기존 패턴과 일관성을 맞춘다.
+
+## STEP 2: 라우트 유형 분류
+
+| 유형 | 파일 | 특징 |
+|---|---|---|
+| **Public 조회** | `route.ts` — GET | 인증 없음, ISR/캐시 적용 가능 |
+| **인증 필요** | `route.ts` — GET/POST | `MENU_API_KEY` 헤더 검증 |
+| **Slack 훅** | `route.ts` — POST | `SLACK_SIGNING_SECRET` 서명 검증 |
+| **Cron** | `route.ts` — GET | `Authorization: Bearer` 검증 |
+| **Revalidate** | `route.ts` — GET | `?secret=` 쿼리 검증 |
+
+## STEP 3: 템플릿
+
+### 기본 GET (Supabase 조회)
+
+```ts
+import {NextRequest, NextResponse} from 'next/server';
+
+import {createClient} from '@/lib/supabase-server';
+
+export const GET = async (req: NextRequest) => {
+  const {searchParams} = req.nextUrl;
+  const start = searchParams.get('start');
+  const end = searchParams.get('end');
+
+  if (!start || !end) {
+    return NextResponse.json({error: 'start, end required'}, {status: 400});
+  }
+
+  const supabase = createClient();
+  const {data, error} = await supabase
+    .from('daily_menu')
+    .select('*')
+    .gte('date', start)
+    .lte('date', end);
+
+  if (error) return NextResponse.json({error: error.message}, {status: 500});
+
+  return NextResponse.json(data);
+};
+```
+
+### API Key 인증 포함
+
+```ts
+const API_KEY = process.env.MENU_API_KEY;
+
+export const GET = async (req: NextRequest) => {
+  if (req.headers.get('x-api-key') !== API_KEY) {
+    return NextResponse.json({error: 'Unauthorized'}, {status: 401});
+  }
+  // ...
+};
+```
+
+### Cron Route
+
+```ts
+export const GET = async (req: NextRequest) => {
+  const auth = req.headers.get('authorization');
+  if (auth !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({error: 'Unauthorized'}, {status: 401});
+  }
+  // ...
+};
+```
+
+## STEP 4: 규칙
+
+- **서버 전용 Supabase**: `createClient()` from `@/lib/supabase-server` — 클라이언트용 import 금지
+- **환경변수 직접 노출 금지**: `NEXT_PUBLIC_` 접두사 없는 변수는 서버에서만
+- **에러 응답 일관성**: `{error: string}` + HTTP 상태 코드
+- **GET 핸들러명**: `export const GET = async (req: NextRequest) =>` (named export)
+- **Vercel Cron**: `vercel.json`의 `crons` 배열에 등록 필요 (이미 있으면 추가)

--- a/.claude/skills/component-scaffold/SKILL.md
+++ b/.claude/skills/component-scaffold/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: component-scaffold
+description: 프로젝트 컨벤션에 맞는 새 컴포넌트·페이지·훅을 생성. "컴포넌트 만들어", "페이지 추가", "훅 만들어" 등 신규 파일 생성 요청 시 발동.
+---
+
+# Component Scaffold
+
+새 파일 생성 전 이 절차를 따른다.
+
+## STEP 1: 타입 분류
+
+요청을 아래 중 하나로 분류한다:
+
+| 타입 | 위치 | 예시 |
+|---|---|---|
+| **Page** | `src/app/<route>/page.tsx` | `/games`, `/nearby` |
+| **Layout** | `src/app/<route>/layout.tsx` | 공유 레이아웃 |
+| **Feature Component** | `src/components/<feature>/` | `VoteButton.tsx` |
+| **Shared Component** | `src/components/@shared/` | 전역 공통 UI |
+| **Hook** | `src/lib/<name>.ts` | `useVote.ts` |
+| **API Route** | `src/app/api/<route>/route.ts` | → api-route-pattern 스킬 사용 |
+
+## STEP 2: 컨벤션 규칙 적용
+
+### 컴포넌트 템플릿
+
+```tsx
+// 1. 'use client' — 클라이언트 전용일 때만
+'use client';
+
+// 2. import 순서: builtin → external → internal → parent → sibling
+import {useState} from 'react';
+
+import {cn} from '@/lib/utils';
+import {SomeType} from '@/types/menu';
+
+// 3. 타입은 파일 상단 interface/type으로
+interface ComponentNameProps {
+  prop: string;
+  optional?: boolean;
+}
+
+// 4. arrow function + export default
+const ComponentName = ({prop, optional = false}: ComponentNameProps) => {
+  // 5. early return
+  if (!prop) return null;
+
+  return (
+    <div className={cn('base-class', optional && 'optional-class')}>
+      {prop}
+    </div>
+  );
+};
+
+export default ComponentName;
+```
+
+### 훅 템플릿
+
+```ts
+'use client';
+
+import {useEffect, useState} from 'react';
+
+export const useHookName = (param: ParamType) => {
+  const [state, setState] = useState<StateType>(initial);
+
+  useEffect(() => {
+    // ...
+  }, [param]);
+
+  return {state};
+};
+```
+
+### 파일명 규칙
+
+- 컴포넌트: `PascalCase.tsx`
+- 훅/유틸: `camelCase.ts`
+- 상수: `UPPER_CASE` (파일명은 camelCase)
+- 타입 파일: `src/types/<domain>.ts`
+
+## STEP 3: 제약 확인
+
+- **300줄/파일** 초과 예상 시 → 분리 계획 제시 후 진행
+- **80줄/함수** 초과 예상 시 → 하위 컴포넌트/함수 추출
+- **중첩 depth ≤ 3**: JSX 중첩 포함
+- **params ≤ 4**: props가 4개 초과하면 객체로 묶기
+
+## STEP 4: 디자인 시스템 적용
+
+컴포넌트에 스타일이 포함되면 `design-system-guard` 스킬의 STEP 2~3 체크를 인라인으로 수행한다.
+(별도 스킬 호출 없이 금지 패턴만 확인)
+
+## STEP 5: 생성 후 보고
+
+```
+✅ 생성 완료
+
+- 파일: src/components/feature/ComponentName.tsx
+- 타입: src/types/domain.ts (필요 시)
+- export: index.ts 업데이트 필요 여부
+```

--- a/.claude/skills/design-system-guard/SKILL.md
+++ b/.claude/skills/design-system-guard/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: design-system-guard
+description: UI·스타일 코드 작성 또는 리뷰 시 DESIGN.md 토큰·규칙 위반을 검출하고 수정 제안. 컴포넌트 구현, 스타일 변경, QA 시 발동.
+---
+
+# Design System Guard
+
+UI 코드를 작성하거나 리뷰하기 전에 이 절차를 따른다.
+
+## STEP 1: DESIGN.md 로드
+
+`DESIGN.md` (repo root)를 Read로 읽는다. 이미 읽었으면 스킵.
+
+## STEP 2: 금지 패턴 체크
+
+대상 파일에서 아래 패턴을 grep/Read로 확인한다.
+
+### 🚫 절대 금지
+
+| 패턴 | 이유 | 대체 |
+|---|---|---|
+| `border` 클래스 (카드 경계) | shadow-only elevation 원칙 | `shadow-[var(--shadow-card)]` |
+| `rounded-*` (풀 스퀘어 원칙 위반) | border-radius: 0 전면 | 물리적 원형 요소만 예외 |
+| 하드코딩 컬러 (`#111`, `#fff`, `gray-*` 등) | 토큰 밖 색상 | `--color-*` 토큰 사용 |
+| UI 이모지 (`🍚`, `✅` 등 텍스트에 직접 삽입) | Iconography 규칙 | lucide 아이콘, 넘버링, 타이포 글리프 |
+| `dark:*` 클래스 | 라이트 단일 테마 | 없음 |
+| `text-red-*`, `text-blue-*` (토큰 미정의) | 토큰 밖 컬러 | 디자인 토큰으로 흡수 필요 |
+
+### ⚠️ 주의 (맥락 확인 필요)
+
+| 패턴 | 확인 사항 |
+|---|---|
+| `text-muted` | 본문에 쓰면 위반 — 캡션/메타 한정 |
+| `text-[*px]` 10px 이하 | 본문 최소 13px, 메타 한정 |
+| `text-accent` / `bg-accent` | 키컬러 남발 금지 — 사용처 6가지만 허용 |
+| `border-b`, `border-t` (구분선) | 헤어라인은 `border-line` 토큰만 허용 |
+
+## STEP 3: 접근성 체크
+
+- 인터랙티브 요소에 `aria-label` / `aria-pressed` / `aria-disabled` 누락 여부
+- 터치 타깃 44px 미만 여부 (`size-9` = 36px → `size-11` = 44px)
+- `focus-visible` 없는 버튼/링크
+- 이미지/아이콘 장식 요소에 `aria-hidden` 누락
+
+## STEP 4: 위반 리포트
+
+위반이 있으면 아래 형식으로 보고한다:
+
+```
+🚨 디자인 시스템 위반 발견
+
+| 파일:줄 | 패턴 | 위반 유형 | 수정 제안 |
+|---|---|---|---|
+| SiteHeader.tsx:42 | `border border-line` | 카드 border 금지 | `shadow-[var(--shadow-card)]` |
+```
+
+위반이 없으면: "✅ 디자인 시스템 규칙 통과"
+
+## STEP 5: 코드 작성 시 토큰 참조
+
+새 컴포넌트/스타일 작성 시 반드시 아래 토큰 목록에서 선택한다.
+
+**배경:** `bg-bg` · `bg-surface` · `bg-surface-warm` · `bg-board` · `bg-board-2`
+**텍스트:** `text-ink` · `text-ink-2` · `text-muted`(캡션한정) · `text-cream` · `text-cream-2` · `text-accent-text`
+**액센트:** `bg-accent` · `text-accent` · `bg-accent-soft` · `bg-accent-deep`
+**비활성:** `bg-down-soft` · `text-down`
+**구분선:** `border-line` (헤어라인 전용)
+**그림자:** `shadow-[var(--shadow-flat)]` · `shadow-[var(--shadow-card)]` · `shadow-[var(--shadow-card-hover)]`
+**형광펜:** `[background:linear-gradient(transparent_40%,var(--color-highlight)_40%)]`

--- a/.claude/skills/start-ticket/SKILL.md
+++ b/.claude/skills/start-ticket/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: start-ticket
+description: Notion 티켓 조회 → 작업 계획 기입 → 브랜치 생성까지 작업 시작 절차 전체를 처리. "작업 시작", "티켓 따서", "MEGA-XX 작업" 등 티켓 기반 작업 착수 시 발동.
+---
+
+# Start Ticket
+
+새 작업을 시작하기 전에 이 절차를 따른다. 브랜치 생성은 반드시 티켓 계획 승인 후에만 진행한다.
+
+## STEP 1: 티켓 식별
+
+사용자 메시지에서 티켓 번호 또는 작업 키워드를 추출한다.
+
+- 번호가 명시된 경우 (`MEGA-50`, `50번` 등): 해당 티켓 직접 조회
+- 번호가 없는 경우: Notion 보드에서 `Status = To Do` 또는 `In Progress` 티켓 목록 조회 후 사용자에게 선택 요청
+
+Notion 데이터베이스 ID: `377cb4f8-4b7f-8012-ad8c-ca1ca0bfad59`
+
+```
+mcp__notion-local__API-query-data-source 로 database_id 조회
+→ filter: { property: "Status", status: { equals: "To Do" } }
+→ 우선순위(P0 > P1 > P2 > P3) 순으로 정렬해서 목록 제시
+```
+
+## STEP 2: 티켓 내용 파악
+
+해당 티켓 페이지를 `mcp__notion-local__API-retrieve-a-page` 로 조회해 아래 항목을 파악한다:
+
+- 제목 (티켓 번호 포함)
+- 현재 설명/요구사항
+- 우선순위, 예상 소요 시간
+- 관련 컴포넌트·파일 (기재된 경우)
+
+## STEP 3: 작업 계획 초안 작성
+
+파악한 티켓 내용을 바탕으로 아래 구조의 작업 계획을 초안한다.
+
+```markdown
+## 작업 계획
+
+### 목표
+[한 줄 — 이 작업이 완료되면 무엇이 달라지는가]
+
+### 구현 범위
+- [ ] 항목 1 (파일명 명시)
+- [ ] 항목 2
+- ...
+
+### 영향 파일
+| 파일 | 변경 유형 | 비고 |
+|---|---|---|
+| src/... | 신규/수정/삭제 | |
+
+### 기술 결정
+- 방식: ...
+- 사용 라이브러리: ...
+- 주의사항: ...
+
+### 완료 기준 (Definition of Done)
+- [ ] 기능 동작 확인
+- [ ] 디자인 시스템 위반 없음
+- [ ] 타입 에러 없음 (`pnpm build` 통과)
+- [ ] lint/format 통과
+```
+
+## STEP 4: 티켓에 계획 기입 + 상태 업데이트
+
+작업 계획 초안을 사용자에게 보여주고 **승인 후** 아래를 실행한다.
+
+1. `mcp__notion-local__API-patch-block-children` 으로 티켓 페이지 본문에 계획 추가
+2. `mcp__notion-local__API-patch-page` 으로 Status → `In Progress` 변경
+
+승인 없이 Notion 업데이트 금지.
+
+## STEP 5: 브랜치 생성
+
+티켓 계획이 승인되고 Notion 업데이트가 완료된 후에만 실행한다.
+
+### 브랜치명 규칙
+
+| 티켓 유형 | 접두사 | 예시 |
+|---|---|---|
+| 신규 기능 | `feat/` | `feat/MEGA-50-notice-board` |
+| 버그 수정 | `fix/` | `fix/MEGA-61-menu-date-overflow` |
+| 리팩터링 | `refactor/` | `refactor/MEGA-72-hero-status` |
+| 문서/설정 | `chore/` | `chore/MEGA-80-env-cleanup` |
+
+- 슬러그: `MEGA-{번호}-{제목-kebab-case}` (영문, 최대 40자)
+- 기준 브랜치: **반드시 `dev`**
+
+```bash
+git fetch upstream
+git checkout dev
+git merge upstream/dev
+git checkout -b feat/MEGA-{번호}-{슬러그}
+```
+
+## STEP 6: 완료 보고
+
+```
+✅ 작업 준비 완료
+
+- 티켓: MEGA-{번호} — {제목}
+- 브랜치: feat/MEGA-{번호}-{슬러그} (dev 기준)
+- Notion: 작업 계획 기입 + In Progress 전환 완료
+
+다음 단계: 구현 시작 (component-scaffold / design-system-guard 스킬 참조)
+```

--- a/.claude/skills/supabase-schema/SKILL.md
+++ b/.claude/skills/supabase-schema/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: supabase-schema
+description: Supabase 테이블 신규 생성·마이그레이션·RLS 정책·TypeScript 타입 레이어 작업. "테이블 만들어", "스키마 추가", "Supabase 설정" 요청 시 발동.
+---
+
+# Supabase Schema
+
+새 테이블이나 스키마 변경 시 이 절차를 따른다.
+작업 티켓은 https://app.notion.com/p/pionari/377cb4f84b7f8012ad8cca1ca0bfad59 에서 관리한다.
+
+## STEP 1: 기존 패턴 참조
+
+`src/lib/supabase-server.ts` 와 `src/types/` 를 읽어 기존 타입·클라이언트 패턴을 파악한다.
+
+## STEP 2: SQL 마이그레이션 작성
+
+```sql
+-- 예시: votes 테이블
+create table if not exists public.votes (
+  id          uuid primary key default gen_random_uuid(),
+  date        date        not null,
+  category    text        not null, -- 'course1' | 'course2' | 'takeout'
+  voter_id    text        not null, -- 익명 ID (GA cookie / localStorage)
+  created_at  timestamptz not null default now()
+);
+
+-- 중복 투표 방지 (같은 날·코스·투표자)
+create unique index if not exists votes_dedup
+  on public.votes (date, category, voter_id);
+
+-- RLS 활성화
+alter table public.votes enable row level security;
+
+-- 정책: 익명 사용자 INSERT만 허용
+create policy "anon insert" on public.votes
+  for insert to anon with check (true);
+
+-- 정책: 집계 조회 허용 (개별 voter_id 노출 없이)
+create policy "select aggregate" on public.votes
+  for select to anon using (true);
+```
+
+## STEP 3: TypeScript 타입 추가
+
+`src/types/` 하위에 도메인별 파일 추가:
+
+```ts
+// src/types/vote.ts
+export type VoteCategory = 'course1' | 'course2' | 'takeout';
+
+export interface Vote {
+  id: string;
+  date: string;       // YYYY-MM-DD
+  category: VoteCategory;
+  voter_id: string;
+  created_at: string;
+}
+
+export interface VoteSummary {
+  category: VoteCategory;
+  count: number;
+}
+```
+
+## STEP 4: 서버사이드 쿼리 함수 추가
+
+`src/lib/api/` 하위에 쿼리 함수 작성:
+
+```ts
+// src/lib/api/getVotes.ts
+import {createClient} from '@/lib/supabase-server';
+import {VoteSummary} from '@/types/vote';
+
+export const getVoteSummary = async (date: string): Promise<VoteSummary[]> => {
+  const supabase = createClient();
+  const {data, error} = await supabase
+    .from('votes')
+    .select('category, count:id.count()')
+    .eq('date', date);
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as VoteSummary[];
+};
+```
+
+## STEP 5: 체크리스트
+
+- [ ] SQL 마이그레이션 작성 (Supabase 대시보드 > SQL Editor에서 실행)
+- [ ] RLS 정책 활성화 확인
+- [ ] TypeScript 타입 추가
+- [ ] 쿼리 함수 추가
+- [ ] 환경변수 추가 필요 여부 확인 (`SUPABASE_SERVICE_ROLE_KEY` 필요 시)
+- [ ] Notion 티켓 상태 → Done 업데이트
+
+## STEP 6: RLS 원칙
+
+- **anon**: INSERT only (투표, 이벤트 로깅)
+- **authenticated**: SELECT + UPDATE (관리자 작업)
+- **service_role**: 제한 없음 (Cron, 서버사이드 집계)
+- voter_id 등 개인 식별 가능 필드는 SELECT 정책에서 집계로만 노출

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,79 +4,143 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MegaBobs is a cafeteria menu viewer for Megazone employees. It provides a web interface and Slack bot integration to browse daily meals by date and course type. Built with Next.js 15 (App Router), deployed on Vercel, backed by Supabase PostgreSQL.
+MegaBobs는 메가존 임직원용 구내식당 메뉴 뷰어입니다. 날짜·코스별 식단 조회, 실시간 운영 상태 표시, Slack 봇 연동, MCP 서버를 제공합니다.
+Next.js 15 (App Router) + Supabase PostgreSQL, Vercel 배포.
 
 ## Commands
 
 ```bash
-pnpm dev            # Dev server with Turbopack
+pnpm dev            # Dev server (Turbopack)
 pnpm build          # Production build
-pnpm lint           # ESLint check
-pnpm lint:fix       # ESLint auto-fix
-pnpm format         # Prettier format
-pnpm format:check   # Prettier check only
+pnpm start          # Production server
+pnpm lint           # ESLint 검사
+pnpm lint:fix       # ESLint 자동 수정
+pnpm format         # Prettier 포맷
+pnpm format:check   # Prettier 검사
+pnpm test           # Vitest 단위 테스트
+pnpm test:watch     # Vitest watch 모드
+pnpm mcp            # MCP 서버 실행 (src/mcp/index.ts)
 ```
-
-No test framework is configured.
 
 ## Architecture
 
 ### Data Flow
 
-Supabase `daily_menu` table → server-side fetch in `page.tsx` (ISR, 6h revalidation) → passed to `MenuSelector` client component → Zustand stores → UI components.
+```
+Supabase daily_menu
+  → page.tsx (Server Component, ISR 6h revalidation)
+  → MenuBoard (Client Component)
+  → useDateStore (Zustand)
+  → DayBar / CourseRow
+```
 
 ### Key Directories
 
-- `src/app/` — Next.js App Router pages and API routes
-- `src/components/` — React components (`layout/` for structural, rest are feature components)
-- `src/lib/` — Supabase client (`supabase-server.ts`), data fetching (`api/getMenu.ts`), utilities (`utils.ts`, `dayjs.ts`)
-- `src/store/` — Zustand store: `useDateStore` (selected date, week navigation)
-- `src/types/` — TypeScript types (`MenuType`, `MenuCategory`, `MealType`, `MenuItemType`)
-- `src/constants/` — Constants for menu categories, meal types, Slack commands
+```
+src/
+├── app/
+│   ├── api/
+│   │   ├── menu/         # GET ?start=&end= — 날짜 범위 메뉴 조회
+│   │   ├── mcp/          # MCP Streamable HTTP 엔드포인트
+│   │   ├── slack/        # POST — 슬래시 커맨드 핸들러
+│   │   │   └── warm/     # GET — Cron 캐시 워밍 (매일 15:00 UTC)
+│   │   └── revalidate/   # GET ?secret= — ISR 강제 재검증 (매일 19:30 UTC)
+│   ├── notice/           # 공지사항 페이지
+│   ├── globals.css       # @theme 토큰 (Tailwind v4)
+│   ├── layout.tsx        # Pretendard 폰트 셀프호스팅, @vercel/analytics
+│   └── page.tsx          # 홈 (ISR, HeroStatus 렌더)
+├── components/
+│   ├── @shared/          # ErrorBoundary, SiteHeader, SiteFooter + index.ts
+│   ├── board/            # MenuBoard, DayBar, CourseRow, BoardEmpty
+│   └── home/             # HeroDate, HomeSide
+├── constants/
+│   ├── menu.ts           # MenuCategoryLabel (코스 카테고리 한글 레이블)
+│   ├── site.ts           # NAV_ITEMS, HOME_ENTRIES, FOOTER_LINKS
+│   └── slack.ts          # Slack 커맨드 맵
+├── lib/
+│   ├── api/getMenu.ts    # Supabase daily_menu 조회 함수
+│   ├── dayjs.ts          # Asia/Seoul 타임존 설정 — 항상 여기서 import
+│   ├── menu-policy.ts    # CAFETERIA 운영 시각 config (단일 소스)
+│   ├── supabase-server.ts
+│   ├── useHasMounted.ts  # SSR/CSR 하이드레이션 불일치 방지 훅
+│   └── utils.ts          # cn(), formatYYYYMMDD(), getWeekDays()
+├── mcp/
+│   ├── index.ts          # MCP 서버 진입점 (stdio transport)
+│   └── server.ts         # MCP 도구 정의
+├── store/
+│   └── useDateStore.ts   # today, selectedDate, currentWeek, 주 이동
+└── types/
+    ├── meal.ts           # MealType
+    ├── menu.ts           # MenuType, MenuCategory, MenuItemType
+    └── notice.ts         # NoticeData
+```
 
 ### API Routes
 
-- `GET /api/menu?start=&end=` — Query menus by date range
-- `POST /api/slack` — Slack slash command handler (오늘/내일/모레/글피)
-- `GET /api/slack/warm` — Cron-triggered cache warming (daily 15:00)
-- `GET /api/revalidate?secret=` — ISR revalidation trigger (daily 19:30)
+| 경로 | 메서드 | 인증 | 용도 |
+|---|---|---|---|
+| `/api/menu` | GET | `x-api-key` | `?start=&end=` 날짜 범위 메뉴 조회 |
+| `/api/slack` | POST | Slack 서명 | 슬래시 커맨드 (오늘/내일/모레/글피) |
+| `/api/slack/warm` | GET | Bearer | Cron 캐시 워밍 (vercel.json 15:00 UTC) |
+| `/api/revalidate` | GET | `?secret=` | ISR 강제 재검증 |
+| `/api/mcp` | GET/POST | — | MCP Streamable HTTP |
 
 ### State Management
 
-One Zustand store manages client state:
-- `useDateStore` — today, selectedDate, currentWeek (Dayjs[]), min/max date bounds, week navigation
+`useDateStore` (Zustand v5) — 클라이언트 날짜 상태 단일 소스:
+- `today`, `selectedDate`, `currentWeek` (Dayjs[])
+- `minDate` (1주 전 월요일), `maxDate` (1주 후 일요일)
+- `setSelectedDate`, `goToPrevWeek`, `goToNextWeek`
+- 범위 이탈 시 `react-hot-toast` 에러 토스트
 
 ### Timezone
 
-All date logic uses `dayjs` configured with `Asia/Seoul` timezone (`src/lib/dayjs.ts`). Always import dayjs from this module, not directly from the package.
+날짜 관련 로직은 모두 `src/lib/dayjs.ts`에서 import. `dayjs` 패키지 직접 import 금지.
 
 ## Code Conventions
 
-### Style Rules (from .cursor/rules and ESLint)
+### Style Rules
 
-- **Arrow functions**: Always use arrow functions for components and modules, with `export default`
-- **Early returns**: Prefer early returns for readability
-- **Const over function**: Use `const fn = () =>` instead of `function fn()`
-- **Naming**: camelCase for variables/functions, PascalCase for components/types, UPPER_CASE for constants
-- **Unused vars**: Prefix with `_` (e.g., `_req`)
-- **Import order**: builtin → external → internal → parent → sibling → index, with blank lines between groups, alphabetized
-- **Max constraints**: 300 lines/file, 80 lines/function, complexity ≤ 10, nesting ≤ 3, params ≤ 4
+- **Arrow functions**: 컴포넌트·모듈 모두 `const Fn = () =>` + `export default`
+- **Early returns**: 조건이 맞지 않으면 조기 반환
+- **Naming**: 변수/함수 camelCase · 컴포넌트/타입 PascalCase · 상수 UPPER_CASE
+- **Unused vars**: `_` 접두사 (예: `_req`)
+- **Import 순서**: builtin → external → internal → parent → sibling → index, 그룹 간 빈 줄, 알파벳 정렬
+- **Max constraints**: 300줄/파일 · 80줄/함수 · complexity ≤ 10 · nesting ≤ 3 · params ≤ 4
 
 ### Prettier
 
-Single quotes, no bracket spacing (`{foo}`), trailing commas (es5), 2-space indent, Tailwind CSS plugin for class sorting.
+Single quotes, no bracket spacing (`{foo}`), trailing commas (es5), 2-space indent, `prettier-plugin-tailwindcss` 클래스 자동 정렬.
 
 ### Styling
 
-Tailwind CSS v4 with custom theme tokens defined in `@theme` inside `src/app/globals.css` (no `tailwind.config.ts`). Light theme only — no dark mode (`next-themes` was removed). Responsive layout with a `min(880px, calc(100% - 40px))` content container; home is a 2-column desktop grid (`1fr 300px`) that collapses to a single column under 920px.
+Tailwind CSS v4 — 토큰은 `src/app/globals.css`의 `@theme` 블록에서 관리 (`tailwind.config.ts` 없음).
+라이트 단일 테마 (`next-themes` 미사용). 콘텐츠 컨테이너 `min(880px, calc(100% - 40px))`, 홈 `1fr 300px` 2컬럼 (920px 미만 1컬럼).
 
 ### Design System
 
-Read `DESIGN.md` (repo root) before any visual or UI change. All tokens, typography, color, spacing, shape, and accessibility rules are defined there. Do not deviate without explicit user approval. In QA, flag any UI code that violates DESIGN.md.
+UI·스타일 작업 전 반드시 `DESIGN.md` (repo root)를 읽는다. 토큰·타이포·컬러·간격·shape·접근성 규칙이 모두 정의되어 있다. 명시적 승인 없이 이탈 금지.
 
 ## Environment Variables
 
-- `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` — Supabase client
-- `SUPABASE_SERVICE_ROLE_KEY` — Server-only Supabase admin key
-- `REVALIDATE_SECRET` — ISR revalidation auth
-- `NEXT_PUBLIC_SITE_URL` — Deployed site URL
+```bash
+NEXT_PUBLIC_SUPABASE_URL=        # Supabase 프로젝트 URL
+NEXT_PUBLIC_SUPABASE_ANON_KEY=   # Supabase anon key (클라이언트)
+SUPABASE_SERVICE_ROLE_KEY=       # Supabase service role key (서버 전용)
+REVALIDATE_SECRET=               # ISR 재검증 인증 토큰
+NEXT_PUBLIC_SITE_URL=            # 배포 URL (예: https://megabobs.com)
+SLACK_SIGNING_SECRET=            # Slack 앱 서명 시크릿
+MENU_API_KEY=                    # /api/menu 인증 키
+```
+
+## Skill Routing
+
+사용자 요청이 아래 조건에 해당하면 **반드시** 해당 스킬을 `Skill` 도구로 먼저 호출한 뒤 진행한다. 직접 `gh`/`git` 명령으로 건너뛰지 말 것.
+
+| 트리거 키워드 | 스킬 | 경로 |
+|---|---|---|
+| "PR 만들어", "PR 생성", "PR 올려", "pr 내줘", `/pr` | `create-pr` | `.claude/skills/create-pr/` |
+| 컴포넌트·페이지·훅 신규 생성, "만들어", "추가해" (UI 파일) | `component-scaffold` | `.claude/skills/component-scaffold/` |
+| UI·스타일 코드 작성 또는 리뷰, DESIGN.md 관련 | `design-system-guard` | `.claude/skills/design-system-guard/` |
+| `src/app/api/*` 추가, "API 만들어", "엔드포인트 추가" | `api-route-pattern` | `.claude/skills/api-route-pattern/` |
+| Supabase 테이블·마이그레이션·RLS·타입 작업 | `supabase-schema` | `.claude/skills/supabase-schema/` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,3 +144,4 @@ MENU_API_KEY=                    # /api/menu 인증 키
 | UI·스타일 코드 작성 또는 리뷰, DESIGN.md 관련 | `design-system-guard` | `.claude/skills/design-system-guard/` |
 | `src/app/api/*` 추가, "API 만들어", "엔드포인트 추가" | `api-route-pattern` | `.claude/skills/api-route-pattern/` |
 | Supabase 테이블·마이그레이션·RLS·타입 작업 | `supabase-schema` | `.claude/skills/supabase-schema/` |
+| "작업 시작", "티켓 따서", "MEGA-XX 작업", 티켓 번호 언급 + 작업 착수 | `start-ticket` | `.claude/skills/start-ticket/` |


### PR DESCRIPTION
## 개요

> **한줄 요약**: Claude Code가 반복 작업(PR 생성, 컴포넌트 생성, 디자인 가드, API/DB 작업, 티켓 착수)을 스킬 절차대로 일관되게 처리하도록 프로젝트 자동화 레이어를 구축

기존에는 스킬이 `create-pr` 하나뿐이었고 CLAUDE.md도 실제 코드베이스와 맞지 않는 부분이 있었습니다.
스킬 5종을 추가하고 CLAUDE.md에 Skill Routing 테이블을 명시해, 트리거 키워드가 감지되면 Claude가 해당 스킬을 먼저 호출하도록 강제합니다.
특히 `start-ticket` 스킬은 Notion 티켓 조회 → 작업 계획 기입 → upstream/dev 기준 브랜치 생성까지 작업 착수 절차 전체를 자동화합니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **스킬 신규** | `design-system-guard/SKILL.md` | DESIGN.md 토큰 위반·접근성 검출 절차 |
| **스킬 신규** | `component-scaffold/SKILL.md` | 컴포넌트·페이지·훅 컨벤션 가이드 + 템플릿 |
| **스킬 신규** | `api-route-pattern/SKILL.md` | Route Handler + Supabase + 인증/Cron 패턴 |
| **스킬 신규** | `supabase-schema/SKILL.md` | SQL 마이그레이션·RLS·타입·쿼리 함수 절차 |
| **스킬 신규** | `start-ticket/SKILL.md` | Notion 티켓 조회 → 계획 기입 → 브랜치 생성 착수 절차 |
| **문서** | `CLAUDE.md` | 실제 디렉토리 트리·API 표·env vars·Skill Routing 테이블로 전면 재작성 |
| **문서** | `README.md` | 스킬 목록 현행화 (5종) |

&nbsp;

## 주요 리뷰 요청사항

- `start-ticket` SKILL.md의 브랜치 생성 시 `upstream/dev` 기준이 현재 팀 브랜치 전략과 맞는지 확인 부탁드립니다
- `design-system-guard` 금지 패턴이 현재 DESIGN.md 규칙과 일치하는지 확인 부탁드립니다

&nbsp;

## 테스트 계획

- [ ] CLAUDE.md Skill Routing 테이블 — PR 요청 시 `create-pr` 스킬 자동 호출 확인
- [ ] CLAUDE.md 디렉토리 트리가 실제 `src/` 구조와 일치 확인
- [ ] `start-ticket` 스킬 — MEGA 티켓 번호 입력 시 Notion 조회 → 계획 기입 → 브랜치 생성 흐름 확인
- [ ] 각 SKILL.md frontmatter `name`/`description` 형식 유효성 확인
- [ ] 프로덕션 코드 변경 없음 — 빌드 영향 없음

---

> 🎭 **오늘의 커밋 시**
>
> 스킬 없이 PR 날리던 그 시절 🫠
> 이제는 `start-ticket`이 티켓 챙기고
> `create-pr`이 본문 써주고
> Claude는 그냥... 버튼만 누른다 🤖

🤖 Generated with [Claude Code](https://claude.com/claude-code)