### PR TITLE
fix: MenuBoard.tsx 중복 import 및 순서 린트 에러 수정

### DIFF
--- a/src/components/board/MenuBoard.tsx
+++ b/src/components/board/MenuBoard.tsx
@@ -3,11 +3,9 @@
 import {CalendarDays, MapPin} from 'lucide-react';
 import {useMemo} from 'react';
 
-import {cn} from '@/lib/utils';
-
 import {MENU_CATEGORIES} from '@/constants/menu';
 import {isNextWeek, isNextWeekPublished} from '@/lib/menu-policy';
-import {formatYYYYMMDD} from '@/lib/utils';
+import {cn, formatYYYYMMDD} from '@/lib/utils';
 import {useDateStore} from '@/store/useDateStore';
 import {MenuType} from '@/types/menu';
 


### PR DESCRIPTION
## 개요

> **한줄 요약**: `MenuBoard.tsx` 중복 import 및 순서 린트 에러 수정

`@/lib/utils`가 두 줄로 중복 임포트되고 그룹 내 빈 줄이 삽입되어 ESLint `import/no-duplicates`, `import/order` 에러가 발생하고 있었습니다.
두 import를 한 줄로 병합하고 순서를 정렬했습니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **Import 정리** | `MenuBoard.tsx` | `cn`, `formatYYYYMMDD` 중복 import 병합 및 알파벳 순서 정렬 |

&nbsp;

## 테스트 계획

- [ ] `pnpm lint` 에러 없음 확인
- [ ] `pnpm build` 클린 빌드 확인
- [ ] 메뉴 보드 렌더링 정상 확인 (기존 기능 미영향)

---

> 🎭 **오늘의 커밋 시**
>
> import 두 줄이 하나가 됐지 🎵
> cn도 format도 한 집에 살지
> 빈 줄 하나 사라졌네 홀가분해
> ESLint가 드디어 웃었어 😄

🤖 Generated with [Claude Code](https://claude.com/claude-code)