### PR TITLE
feat: [공지사항] 정적 TS 기반 공지 시스템 및 헤더 벨 애니메이션 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,6 +46,16 @@
   50%       { opacity: 0.55; }
 }
 
+@keyframes bellRingLoop {
+  /* 0~18% 실제 흔들림 (~0.7s @ 4s cycle), 나머지는 정지 */
+  0%   { transform: rotate(0deg); }
+  4%   { transform: rotate(-16deg); }
+  9%   { transform: rotate(14deg); }
+  13%  { transform: rotate(-8deg); }
+  16%  { transform: rotate(6deg); }
+  18%, 100% { transform: rotate(0deg); }
+}
+
 body {
   background: var(--color-bg);
   color: var(--color-ink);

--- a/src/app/notice/page.tsx
+++ b/src/app/notice/page.tsx
@@ -1,9 +1,8 @@
 import type {Metadata} from 'next';
 
-import noticeData from '@/../data/notices.json';
 import {SiteFooter, SiteHeader} from '@/components/@shared';
 import dayjs from '@/lib/dayjs';
-import type {NoticeData} from '@/types/notice';
+import {getAnnouncements} from '@/lib/getAnnouncements';
 
 export const metadata: Metadata = {
   title: '공지사항 — MegaBobs',
@@ -11,7 +10,7 @@ export const metadata: Metadata = {
 };
 
 export default function NoticePage() {
-  const {notices, makers} = noticeData as NoticeData;
+  const notices = getAnnouncements();
 
   return (
     <>
@@ -27,32 +26,35 @@ export default function NoticePage() {
 
         {notices.length > 0 ? (
           <div className="flex flex-col">
-            {notices.map((n, i) => (
-              <article
-                key={n.id}
-                className={`flex gap-5 border-b border-line px-1 py-5 ${i === 0 ? 'border-t-2 border-t-ink' : ''}`}
-              >
-                <div className="w-16 shrink-0">
-                  <b className="block text-[17px] font-extrabold">
-                    {dayjs.tz(n.publishedAt).format('M.D')}
-                  </b>
-                  <span className="block text-[11px] text-muted">
-                    {dayjs.tz(n.publishedAt).format('YYYY')}
-                  </span>
-                </div>
-                <div className="flex-1">
-                  <h3 className="flex items-center gap-2 text-base font-extrabold">
-                    {n.title}
-                    {n.isNew && (
-                      <span className="bg-accent px-1.5 py-0.5 text-[9.5px] font-extrabold text-ink">
-                        NEW
-                      </span>
-                    )}
-                  </h3>
-                  <p className="mt-1.5 text-[13.5px] leading-relaxed text-ink-2">{n.body}</p>
-                </div>
-              </article>
-            ))}
+            {notices.map((n, i) => {
+              const isNew = dayjs().tz().diff(dayjs.tz(n.publishedAt), 'day') < 7;
+              return (
+                <article
+                  key={n.id}
+                  className={`flex gap-5 border-b border-line px-1 py-5 ${i === 0 ? 'border-t-2 border-t-ink' : ''}`}
+                >
+                  <div className="w-16 shrink-0">
+                    <b className="block text-[17px] font-extrabold">
+                      {dayjs.tz(n.publishedAt).format('M.D')}
+                    </b>
+                    <span className="block text-[11px] text-muted">
+                      {dayjs.tz(n.publishedAt).format('YYYY')}
+                    </span>
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="flex items-center gap-2 text-base font-extrabold">
+                      {n.title}
+                      {isNew && (
+                        <span className="bg-accent px-1.5 py-0.5 text-[9.5px] font-extrabold text-ink">
+                          NEW
+                        </span>
+                      )}
+                    </h3>
+                    <p className="mt-1.5 text-[13.5px] leading-relaxed text-ink-2">{n.body}</p>
+                  </div>
+                </article>
+              );
+            })}
           </div>
         ) : (
           <div className="border-t-2 border-t-ink px-1 py-12 text-center text-[13.5px] text-muted">
@@ -60,26 +62,6 @@ export default function NoticePage() {
           </div>
         )}
 
-        <section id="makers" className="mt-11 pb-16">
-          <h2 className="border-b-2 border-ink pb-3 text-lg font-extrabold">만든 사람들</h2>
-          <div className="mt-4 grid grid-cols-2 gap-4 max-[560px]:grid-cols-1">
-            {makers.map((m) => (
-              <div key={m.name} className="shadow-flat border border-line bg-surface p-5">
-                <h3 className="text-[15.5px] font-extrabold">{m.name}</h3>
-                <p className="mt-0.5 text-xs text-muted">{m.role}</p>
-                <a
-                  href={`mailto:${m.email}`}
-                  className="mt-2 inline-block border-b border-accent-soft pb-px text-xs font-bold text-accent-text"
-                >
-                  {m.email}
-                </a>
-              </div>
-            ))}
-          </div>
-          <p className="mt-3.5 text-xs leading-relaxed text-muted">
-            점심시간을 아껴 만들고 있어요. 버그·아이디어·맛집 제보 모두 환영해요.
-          </p>
-        </section>
       </main>
       <SiteFooter />
     </>

--- a/src/components/@shared/SiteHeader.tsx
+++ b/src/components/@shared/SiteHeader.tsx
@@ -5,22 +5,17 @@ import Link from 'next/link';
 import {usePathname} from 'next/navigation';
 import {useEffect, useState} from 'react';
 
-import noticeData from '@/../data/notices.json';
 import {NAV_ITEMS} from '@/constants/site';
-import dayjs from '@/lib/dayjs';
+import {getAnnouncements, hasNewAnnouncement} from '@/lib/getAnnouncements';
 import {useHasMounted} from '@/lib/useHasMounted';
 import {cn} from '@/lib/utils';
-import type {NoticeData} from '@/types/notice';
 
-const {notices} = noticeData as NoticeData;
-
-const hasRecentNotice = () =>
-  notices.some((n) => dayjs().tz().diff(dayjs.tz(n.publishedAt), 'day') < 7);
+const announcements = getAnnouncements();
 
 const SiteHeader = () => {
   const pathname = usePathname();
   const mounted = useHasMounted();
-  const showNoticeDot = mounted && hasRecentNotice();
+  const showNoticeDot = mounted && hasNewAnnouncement(announcements);
   const [scrolled, setScrolled] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -36,7 +31,9 @@ const SiteHeader = () => {
 
   useEffect(() => {
     document.body.style.overflow = menuOpen ? 'hidden' : '';
-    return () => {document.body.style.overflow = '';};
+    return () => {
+      document.body.style.overflow = '';
+    };
   }, [menuOpen]);
 
   return (
@@ -44,7 +41,7 @@ const SiteHeader = () => {
       <header
         className={cn(
           'sticky top-0 z-50 transition-all duration-300',
-          scrolled || menuOpen ? 'bg-white/70 backdrop-blur-xl' : 'bg-transparent'
+          scrolled || menuOpen ? 'bg-white/70 backdrop-blur-xl' : 'bg-transparent',
         )}
       >
         <div className="mx-auto flex h-14 w-[min(880px,calc(100%-40px))] items-center gap-7">
@@ -66,7 +63,7 @@ const SiteHeader = () => {
                     active
                       ? 'text-ink shadow-[inset_0_-2px_0_var(--color-accent)]'
                       : 'text-muted hover:text-ink-2',
-                    item.disabled && 'cursor-default opacity-50'
+                    item.disabled && 'cursor-default opacity-50',
                   )}
                 >
                   {item.label}
@@ -87,7 +84,14 @@ const SiteHeader = () => {
             aria-label="공지사항"
             className="relative flex size-9 items-center justify-center text-ink-2 max-[640px]:hidden"
           >
-            <Bell size={17} strokeWidth={2.2} />
+            <span
+              className={cn(
+                'origin-top',
+                showNoticeDot && 'animate-[bellRingLoop_4s_ease-in-out_infinite]',
+              )}
+            >
+              <Bell size={17} strokeWidth={2.2} />
+            </span>
             {showNoticeDot && (
               <span aria-hidden className="absolute top-[7px] right-[6px] size-1.5 bg-accent" />
             )}
@@ -101,9 +105,19 @@ const SiteHeader = () => {
               aria-label="공지사항"
               className="relative flex size-9 items-center justify-center text-ink-2"
             >
-              <Bell size={17} strokeWidth={2.2} />
+              <span
+                className={cn(
+                  'origin-top',
+                  showNoticeDot && 'animate-[bellRingLoop_4s_ease-in-out_infinite]',
+                )}
+              >
+                <Bell size={17} strokeWidth={2.2} />
+              </span>
               {showNoticeDot && (
-                <span aria-hidden className="absolute top-[7px] right-[6px] size-1.5 bg-accent" />
+                <span
+                  aria-hidden
+                  className="absolute top-[7px] right-[6px] size-1.5 bg-accent"
+                />
               )}
             </Link>
             <button
@@ -121,15 +135,15 @@ const SiteHeader = () => {
       {/* 모바일 메뉴 — header 밖 fixed, stacking context 영향 없음 */}
       <div
         className={cn(
-          'fixed inset-0 top-14 z-40 min-[641px]:hidden',
+          'fixed inset-x-0 bottom-0 top-14 z-40 min-[641px]:hidden',
           'bg-[var(--color-bg)]',
           'transition-all duration-200 ease-in-out',
           menuOpen
-            ? 'opacity-100 translate-y-0 pointer-events-auto'
-            : 'opacity-0 -translate-y-2 pointer-events-none'
+            ? 'pointer-events-auto translate-y-0 opacity-100'
+            : 'pointer-events-none -translate-y-2 opacity-0',
         )}
       >
-        <nav className="mx-auto w-[min(880px,calc(100%-40px))] flex flex-col pb-4 pt-1">
+        <nav className="mx-auto flex w-[min(880px,calc(100%-40px))] flex-col pb-4 pt-1">
           {NAV_ITEMS.map((item) => {
             const active = pathname === item.href;
             return (
@@ -139,9 +153,9 @@ const SiteHeader = () => {
                 aria-disabled={item.disabled}
                 onClick={() => setMenuOpen(false)}
                 className={cn(
-                  'flex items-center justify-between py-3.5 text-[15px] font-semibold border-b border-line/50',
+                  'flex items-center justify-between border-b border-line/50 py-3.5 text-[15px] font-semibold',
                   active ? 'text-ink' : 'text-ink-2',
-                  item.disabled && 'cursor-default opacity-40'
+                  item.disabled && 'cursor-default opacity-40',
                 )}
               >
                 {item.label}

--- a/src/components/@shared/index.ts
+++ b/src/components/@shared/index.ts
@@ -1,3 +1,3 @@
 export {default as ErrorBoundary} from './ErrorBoundary';
-export {default as SiteHeader} from './SiteHeader';
 export {default as SiteFooter} from './SiteFooter';
+export {default as SiteHeader} from './SiteHeader';

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -1,4 +1,4 @@
-import type { Notice } from '@/types/notice';
+import type {Notice} from '@/types/notice';
 
 export const ANNOUNCEMENTS: Notice[] = [
     {

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -1,0 +1,11 @@
+import type { Notice } from '@/types/notice';
+
+export const ANNOUNCEMENTS: Notice[] = [
+    {
+        id: 'dev-001',
+        title: '[DEV] 공지 배너 테스트 — 이 메시지는 개발 환경에서만 보여요',
+        body: 'env: development 필터링 확인용입니다.',
+        publishedAt: '2026-06-01T09:00:00+09:00',
+        env: ['development'],
+    },
+];

--- a/src/lib/getAnnouncements.ts
+++ b/src/lib/getAnnouncements.ts
@@ -1,0 +1,16 @@
+import {ANNOUNCEMENTS} from '@/data/announcements';
+import dayjs from '@/lib/dayjs';
+import type {Notice} from '@/types/notice';
+
+export const getAnnouncements = (): Notice[] => {
+  const now = dayjs();
+  const env = process.env.NODE_ENV as 'development' | 'production';
+  return ANNOUNCEMENTS.filter(
+    (n) => n.env.includes(env) && !dayjs(n.publishedAt).isAfter(now),
+  );
+};
+
+export const hasNewAnnouncement = (announcements: Notice[]): boolean =>
+  announcements.some(
+    (n) => dayjs().tz().diff(dayjs.tz(n.publishedAt), 'day') < 7,
+  );

--- a/src/types/notice.ts
+++ b/src/types/notice.ts
@@ -1,9 +1,11 @@
+export type NoticeEnv = 'development' | 'production';
+
 export type Notice = {
   id: string;
   title: string;
   body: string;
   publishedAt: string;
-  isNew: boolean;
+  env: NoticeEnv[];
 };
 
 export type Maker = {


### PR DESCRIPTION
## 개요

> **한줄 요약**: JSON 기반 공지 데이터를 타입-안전한 TypeScript 파일로 교체하고, 헤더 벨 아이콘에 신규 공지 애니메이션을 추가합니다

기존 `data/notices.json`은 타입 검증 없이 캐스팅해서 사용했고 `isNew` 필드를 데이터에 하드코딩해야 했습니다.
정적 TS 파일(`src/data/announcements.ts`)로 전환해 타입 안전성을 확보하고, `env` 필드로 개발/프로덕션 환경별 노출 제어를 추가했습니다.
또한 신규 공지가 있을 때 벨 아이콘이 흔들리는 `bellRingLoop` 애니메이션을 구현했습니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **공지 데이터** | `announcements.ts` | 공지 상수 정의 (env 필터, 타입 안전) |
| **공지 유틸** | `getAnnouncements.ts` | env/날짜 필터링 + hasNewAnnouncement 함수 |
| **타입 정의** | `notice.ts` | isNew 제거, NoticeEnv / env[] 추가 |
| **공지 페이지** | `notice/page.tsx` | getAnnouncements 연동, isNew 동적 계산, makers 섹션 제거 |
| **헤더 UX** | `SiteHeader.tsx`, `globals.css` | 벨 아이콘 bellRingLoop 애니메이션, 배럴 정렬 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 사용자
    participant 헤더 as SiteHeader
    participant 공지페이지 as NoticePage
    participant 공지유틸 as getAnnouncements
    participant 데이터 as ANNOUNCEMENTS

    사용자->>헤더: 페이지 로드
    헤더->>공지유틸: getAnnouncements()
    공지유틸->>데이터: ANNOUNCEMENTS 읽기
    공지유틸-->>헤더: env·날짜 필터링된 공지 목록
    헤더->>헤더: hasNewAnnouncement() → showNoticeDot
    Note over 헤더: 7일 이내 공지 있으면 bellRingLoop 애니메이션 + 빨간 점

    사용자->>공지페이지: /notice 이동
    공지페이지->>공지유틸: getAnnouncements()
    공지유틸-->>공지페이지: 필터링된 공지 목록
    공지페이지->>공지페이지: publishedAt 기준 isNew 동적 계산
```

&nbsp;

## 주요 리뷰 요청사항

- `isNew`를 데이터 필드에서 제거하고 런타임에 7일 기준으로 동적 계산하도록 변경했습니다 — 기준 일수나 계산 방식에 의견이 있으시면 알려주세요
- `SiteHeader`에서 `getAnnouncements()`를 모듈 최상단(컴포넌트 외부)에서 호출합니다 — CSR 환경에서 `process.env.NODE_ENV`는 번들 타임에 인라인되므로 문제없지만 의견 부탁드립니다

&nbsp;

## 테스트 계획

- [ ] `/notice` 페이지에서 공지 목록 정상 렌더링 확인
- [ ] 개발 환경에서 `env: ['development']` 공지가 노출되는지 확인
- [ ] `publishedAt`이 7일 이내인 공지에 NEW 배지와 벨 애니메이션 표시 확인
- [ ] `publishedAt`이 7일 이상 지난 공지에 NEW 배지·벨 없음 확인
- [ ] 헤더 벨 아이콘 bellRingLoop 애니메이션 Desktop / Mobile 동작 확인
- [ ] 기존 식단 메뉴 조회 기능 미영향 확인

---

> 🎭 **오늘의 커밋 시**
>
> JSON에서 TS로 이사했어요 🏠
> `isNew`는 필드를 떠나 계산으로 살아남고 🧮
> 벨은 딩동딩동 흔들리며 새 공지를 알리죠 🔔
> makers는 조용히 퇴장... 언젠간 돌아오겠지 👋

🤖 Generated with [Claude Code](https://claude.com/claude-code)