### PR TITLE
feat: [법적 페이지] 이용약관·개인정보처리방침·문의 페이지 추가 및 SEO 설정

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,18 +121,23 @@ src/
 │   │   ├── slack/        # POST — 슬래시 커맨드, GET warm — 캐시 워밍
 │   │   └── revalidate/   # GET ?secret= — ISR 강제 재검증
 │   ├── notice/           # 공지사항 페이지
+│   ├── terms/            # 이용약관 페이지
+│   ├── privacy/          # 개인정보처리방침 페이지
+│   ├── contact/          # 문의 페이지
+│   ├── sitemap.ts        # 동적 sitemap.xml
+│   ├── robots.ts         # robots.txt
 │   ├── layout.tsx
 │   └── page.tsx          # 홈 (ISR, HeroStatus 렌더)
 ├── assets/
 │   └── fonts/            # Pretendard 셀프호스팅 폰트
 ├── components/
-│   ├── @shared/          # ErrorBoundary, SiteHeader, SiteFooter, PageLayout
+│   ├── @shared/          # ErrorBoundary, SiteHeader, SiteFooter, PageLayout, LegalPageLayout
 │   ├── menu/             # MenuBoard (_MenuBoardEmpty, _MenuBoardCourseRow, _MenuBoardDayBar)
 │   └── home/             # HeroStatus, HeroDate
 ├── constants/
 │   ├── cafeteria.ts      # CAFETERIA 운영 시각 config (단일 소스)
 │   ├── menu.ts           # 코스 카테고리 한글 레이블
-│   ├── site.ts           # NAV_ITEMS, FOOTER_LINKS
+│   ├── site.ts           # NAV_ITEMS, FOOTER_LINKS, CONTACTS
 │   └── slack.ts          # Slack 커맨드 맵
 ├── data/
 │   └── announcements.ts  # 정적 공지 데이터 (TS 배열)

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,43 @@
+import { Mail } from 'lucide-react';
+import type { Metadata } from 'next';
+
+
+import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
+import { CONTACTS, SITE_NAME } from '@/constants/site';
+
+export const metadata: Metadata = {
+  title: `문의 — ${SITE_NAME}`,
+  description: `${SITE_NAME} 이용 문의 및 버그 제보는 이 페이지에서 제작자에게 직접 연락하세요.`,
+  robots: { index: false },
+  alternates: { canonical: '/contact' },
+};
+
+const ContactPage = () => (
+  <>
+    <SiteHeader />
+    <PageLayout
+      eyebrow="문의"
+      title="궁금한 점이 있으신가요?"
+      description="아래 이메일로 문의해 주세요."
+    >
+      <div className="grid grid-cols-2 gap-3">
+        {CONTACTS.map(({ name, email }) => (
+          <a
+            key={email}
+            href={`mailto:${email}`}
+            className="bg-surface-warm flex flex-col gap-2 p-4"
+          >
+            <span className="text-ink text-[14px] font-extrabold">{name}</span>
+            <span className="text-muted flex items-center gap-1.5 text-[12px]">
+              <Mail size={12} />
+              {email}
+            </span>
+          </a>
+        ))}
+      </div>
+    </PageLayout>
+    <SiteFooter />
+  </>
+);
+
+export default ContactPage;

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,135 @@
+import type { Metadata } from 'next';
+
+import { LegalPageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
+import {
+  legalSectionBodyClass,
+  legalSectionClass,
+  legalSectionListClass,
+  legalSectionTableClass,
+  legalSectionTdClass,
+  legalSectionThClass,
+  legalSectionTitleClass,
+} from '@/components/@shared/layout/LegalPageLayout/LegalPageLayout.styles';
+import { SITE_NAME } from '@/constants/site';
+
+export const metadata: Metadata = {
+  title: '개인정보처리방침',
+  description: `${SITE_NAME} 개인정보처리방침`,
+  robots: { index: false },
+  alternates: { canonical: '/privacy' },
+};
+
+const TOC_ITEMS = [
+  { id: 'collected-info', label: '수집하는 정보' },
+  { id: 'purpose', label: '정보 이용 목적' },
+  { id: 'retention', label: '보관 기간 및 파기' },
+  { id: 'third-party', label: '제3자 제공' },
+  { id: 'user-rights', label: '이용자 권리' },
+  { id: 'contact', label: '문의' },
+];
+
+const PrivacyPage = () => (
+  <>
+    <SiteHeader />
+    <LegalPageLayout
+      title="개인정보처리방침"
+      updatedAt="2026. 6. 8."
+      tocItems={TOC_ITEMS}
+    >
+      <section id="collected-info" className={legalSectionClass}>
+        <h2 className={legalSectionTitleClass}>1. 수집하는 정보</h2>
+        <p className={legalSectionBodyClass}>
+          {SITE_NAME}는 개인정보를 수집하지 않습니다. 맛 평가 투표 및 식전
+          픽 기능의 중복 방지를 위해 브라우저의 localStorage에 익명
+          식별자(투표자 ID)를 자동 생성하여 저장합니다. 이 식별자는 개인을
+          특정할 수 없는 무작위 값(UUID)이며, 서버에 저장되지 않습니다.
+        </p>
+      </section>
+
+      <section id="purpose" className={legalSectionClass}>
+        <h2 className={legalSectionTitleClass}>2. 정보 이용 목적</h2>
+        <p className={legalSectionBodyClass}>
+          수집된 익명 식별자는 다음 목적으로만 사용됩니다.
+        </p>
+        <ul className={legalSectionListClass}>
+          <li>맛 평가 투표 및 식전 픽의 중복 제출 방지</li>
+          <li>
+            재미로 보는 비공식 수요 예측 집계 — 로그인 기반이 아니므로 정확하지
+            않으며, 구내식당 운영에 실제로 활용되지 않습니다
+          </li>
+        </ul>
+      </section>
+
+      <section id="retention" className={legalSectionClass}>
+        <h2 className={legalSectionTitleClass}>3. 보관 기간 및 파기</h2>
+        <p className={legalSectionBodyClass}>
+          데이터베이스에 저장된 투표 및 픽 데이터는 생성일로부터
+          <b> 2주 후 자동 삭제</b>됩니다. 브라우저 localStorage에 저장된
+          익명 식별자는 이용자가 직접 브라우저 설정에서 삭제할 수 있으며,
+          삭제 후에도 서비스 이용은 가능합니다.
+        </p>
+      </section>
+
+      <section id="third-party" className={legalSectionClass}>
+        <h2 className={legalSectionTitleClass}>4. 제3자 제공</h2>
+        <p className={legalSectionBodyClass}>
+          수집된 정보는 제3자에게 판매하거나 마케팅 목적으로 공유하지 않습니다.
+          서비스 운영을 위해 아래 외부 서비스를 이용합니다.
+        </p>
+        <table className={legalSectionTableClass}>
+          <thead>
+            <tr>
+              <th className={legalSectionThClass}>서비스</th>
+              <th className={legalSectionThClass}>용도</th>
+              <th className={legalSectionThClass}>처리 내용</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className={legalSectionTdClass}>Supabase</td>
+              <td className={legalSectionTdClass}>데이터베이스</td>
+              <td className={legalSectionTdClass}>
+                식단 데이터, 투표·픽 저장
+              </td>
+            </tr>
+            <tr>
+              <td className={legalSectionTdClass}>Vercel</td>
+              <td className={legalSectionTdClass}>호스팅</td>
+              <td className={legalSectionTdClass}>서비스 배포 및 엣지 처리</td>
+            </tr>
+            <tr>
+              <td className={legalSectionTdClass}>Slack</td>
+              <td className={legalSectionTdClass}>봇 연동</td>
+              <td className={legalSectionTdClass}>
+                {'/밥'} 슬래시 커맨드 처리
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="user-rights" className={legalSectionClass}>
+        <h2 className={legalSectionTitleClass}>5. 이용자 권리</h2>
+        <p className={legalSectionBodyClass}>
+          이용자는 브라우저 설정에서 사이트 데이터(localStorage)를 삭제하여
+          익명 식별자를 제거할 수 있습니다. 삭제 후 재접속 시 새로운 식별자가
+          자동으로 생성되며, 이전 투표·픽 이력은 복구되지 않습니다.
+        </p>
+      </section>
+
+      <section id="contact" className={legalSectionClass}>
+        <h2 className={legalSectionTitleClass}>6. 문의</h2>
+        <p className={legalSectionBodyClass}>
+          개인정보 처리에 관한 문의는{' '}
+          <a href="/contact" className="underline">
+            문의
+          </a>{' '}
+          페이지를 통해 연락해 주세요.
+        </p>
+      </section>
+    </LegalPageLayout>
+    <SiteFooter />
+  </>
+);
+
+export default PrivacyPage;

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next';
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.megabobs.com';
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -11,6 +11,6 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ['/api/'],
       },
     ],
-    sitemap: `${siteUrl}/sitemap.xml`,
+    sitemap: `${SITE_URL}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,17 +1,17 @@
 import type { MetadataRoute } from 'next';
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.megabobs.com';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: siteUrl,
+      url: SITE_URL,
       lastModified: new Date(),
       changeFrequency: 'daily',
       priority: 1,
     },
     {
-      url: `${siteUrl}/notice`,
+      url: `${SITE_URL}/notice`,
       lastModified: new Date(),
       changeFrequency: 'weekly',
       priority: 0.7,

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,127 @@
+import type { Metadata } from 'next';
+
+import { LegalPageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
+import {
+  legalSectionBodyClass,
+  legalSectionClass,
+  legalSectionListClass,
+  legalSectionTitleClass,
+} from '@/components/@shared/layout/LegalPageLayout/LegalPageLayout.styles';
+import { SITE_NAME } from '@/constants/site';
+
+export const metadata: Metadata = {
+  title: '이용약관',
+  description: `${SITE_NAME} 서비스 이용약관`,
+  robots: { index: false },
+  alternates: { canonical: '/terms' },
+};
+
+const TOC_ITEMS = [
+  { id: 'service-overview', label: '서비스 개요' },
+  { id: 'usage-terms', label: '이용 조건' },
+  { id: 'how-to-use', label: '서비스 이용 방법' },
+  { id: 'prohibited', label: '금지 행위' },
+  { id: 'changes', label: '서비스 변경·중단' },
+  { id: 'disclaimer', label: '면책 조항' },
+  { id: 'contact', label: '문의' },
+];
+
+const TermsPage = () => (
+  <>
+    <SiteHeader />
+    <LegalPageLayout
+      title="이용약관"
+      updatedAt="2026. 6. 8."
+      tocItems={TOC_ITEMS}
+    >
+      <section id="service-overview" className={legalSectionClass}>
+        <h2 className={legalSectionTitleClass}>1. 서비스 개요</h2>
+        <p className={legalSectionBodyClass}>
+          {SITE_NAME}는 메가존 직원이 구내식당 메뉴 확인의 불편함을 해소하기
+          위해 자발적으로 만든 비공식 사이드 프로젝트입니다. 메가존이 운영하거나 공식
+          승인한 서비스가 아닙니다. 날짜별 식단 확인, 코스별 맛 평가 투표,
+          식전 픽 선택 등의 기능을 무상으로 제공합니다.
+        </p>
+      </section>
+
+      <section id="usage-terms" className={legalSectionClass}>
+        <h2 className={legalSectionTitleClass}>2. 이용 조건</h2>
+        <p className={legalSectionBodyClass}>
+          별도 회원가입이나 로그인 없이 누구나 이용할 수 있습니다. 서비스에
+          접속하면 본 약관에 동의한 것으로 간주합니다.
+        </p>
+      </section>
+
+      <section id="how-to-use" className={legalSectionClass}>
+        <h2 className={legalSectionTitleClass}>3. 서비스 이용 방법</h2>
+        <p className={legalSectionBodyClass}>
+          본 서비스는 다음 기능을 제공합니다.
+        </p>
+        <ul className={legalSectionListClass}>
+          <li>
+            <b>식단표 조회</b> — 주간 캘린더에서 날짜를 선택해 코스1·코스2·테이크아웃
+            메뉴와 칼로리 정보를 확인할 수 있습니다.
+          </li>
+          <li>
+            <b>맛 평가 투표</b> — 각 코스에 대해 평가할 수 있습니다. 하루
+            코스당 1회만 투표 가능합니다.
+          </li>
+          <li>
+            <b>식전 픽</b> — 오늘 먹을 코스(코스1·코스2·테이크아웃)를 미리
+            선택해 집계를 확인할 수 있습니다.
+          </li>
+          <li>
+            <b>Slack 봇</b> — {'/밥'} 슬래시 커맨드로 오늘·내일·모레·글피의
+            식단을 조회할 수 있습니다.
+          </li>
+        </ul>
+      </section>
+
+      <section id="prohibited" className={legalSectionClass}>
+        <h2 className={legalSectionTitleClass}>4. 금지 행위</h2>
+        <p className={legalSectionBodyClass}>
+          이용자는 다음 행위를 해서는 안 됩니다.
+        </p>
+        <ul className={legalSectionListClass}>
+          <li>자동화 프로그램·스크립트를 이용한 대량 요청 또는 데이터 수집</li>
+          <li>타인의 투표·픽 결과를 조작하는 행위</li>
+          <li>서비스 인프라에 과도한 부하를 발생시키는 행위</li>
+          <li>서비스 운영을 방해하는 일체의 행위</li>
+        </ul>
+      </section>
+
+      <section id="changes" className={legalSectionClass}>
+        <h2 className={legalSectionTitleClass}>5. 서비스 변경·중단</h2>
+        <p className={legalSectionBodyClass}>
+          본 서비스는 개인이 자유 시간에 유지·관리하는 비공식 프로젝트로,
+          예고 없이 변경되거나 중단될 수 있습니다. 중요한 변경사항은
+          공지사항 페이지를 통해 안내하도록 노력합니다.
+        </p>
+      </section>
+
+      <section id="disclaimer" className={legalSectionClass}>
+        <h2 className={legalSectionTitleClass}>6. 면책 조항</h2>
+        <p className={legalSectionBodyClass}>
+          표시되는 식단 정보는 공식적으로 제공받은 데이터가 아니며 실제
+          메뉴와 다를 수 있습니다. 정보의 정확성·완전성을 보장하지 않으며,
+          이로 인한 불이익에 대해 제작자는 책임을 지지 않습니다. 시스템
+          장애·점검 등으로 인한 서비스 중단에도 동일하게 적용됩니다.
+        </p>
+      </section>
+
+      <section id="contact" className={legalSectionClass}>
+        <h2 className={legalSectionTitleClass}>7. 문의</h2>
+        <p className={legalSectionBodyClass}>
+          서비스 관련 문의는{' '}
+          <a href="/contact" className="underline">
+            문의
+          </a>{' '}
+          페이지를 통해 연락해 주세요.
+        </p>
+      </section>
+    </LegalPageLayout>
+    <SiteFooter />
+  </>
+);
+
+export default TermsPage;

--- a/src/components/@shared/layout/LegalPageLayout/LegalPageLayout.styles.ts
+++ b/src/components/@shared/layout/LegalPageLayout/LegalPageLayout.styles.ts
@@ -1,0 +1,31 @@
+// 페이지 래퍼
+export const legalMainClass = 'py-12';
+export const legalContainerClass = 'mx-auto w-[min(880px,calc(100%-40px))]';
+export const legalContentClass = 'max-w-[680px]';
+
+// 헤더
+export const legalEyebrowClass =
+  'text-muted text-[11px] font-extrabold uppercase tracking-widest';
+export const legalTitleClass =
+  'text-ink mt-2 text-[27px] font-extrabold leading-tight';
+export const legalUpdatedAtClass = 'text-muted mt-2 text-[12px]';
+
+// 목차
+export const tocWrapClass = 'bg-surface-warm shadow-flat mt-8 p-5';
+export const tocTitleClass = 'text-ink mb-3 text-[12px] font-extrabold';
+export const tocListClass = 'space-y-1.5';
+export const tocLinkClass =
+  'text-ink-2 hover:text-ink text-[13px] transition-colors duration-150';
+
+// 섹션 — pages에서 import해서 사용
+export const legalSectionClass = 'mt-10 scroll-mt-[72px]';
+export const legalSectionTitleClass =
+  'border-line text-ink border-t pt-5 text-[17px] font-extrabold';
+export const legalSectionBodyClass =
+  'text-ink-2 mt-4 text-[13.5px] leading-relaxed break-keep';
+export const legalSectionListClass =
+  'text-ink-2 mt-3 list-disc space-y-2 pl-5 text-[13.5px] leading-relaxed break-keep';
+export const legalSectionTableClass = 'mt-4 w-full border-collapse text-[13px]';
+export const legalSectionThClass =
+  'bg-surface-warm border-line text-ink border px-4 py-2.5 text-left text-[12px] font-extrabold';
+export const legalSectionTdClass = 'border-line text-ink-2 border px-4 py-2.5';

--- a/src/components/@shared/layout/LegalPageLayout/LegalPageLayout.tsx
+++ b/src/components/@shared/layout/LegalPageLayout/LegalPageLayout.tsx
@@ -1,0 +1,47 @@
+import { LegalPageLayoutProps } from './LegalPageLayout.types';
+import {
+  legalContainerClass,
+  legalContentClass,
+  legalEyebrowClass,
+  legalMainClass,
+  legalTitleClass,
+  legalUpdatedAtClass,
+  tocLinkClass,
+  tocListClass,
+  tocTitleClass,
+  tocWrapClass,
+} from './LegalPageLayout.styles';
+
+const LegalPageLayout = ({
+  title,
+  updatedAt,
+  tocItems,
+  children,
+}: LegalPageLayoutProps) => (
+  <main className={legalMainClass}>
+    <div className={legalContainerClass}>
+      <div className={legalContentClass}>
+        <p className={legalEyebrowClass}>법적 고지</p>
+        <h1 className={legalTitleClass}>{title}</h1>
+        <p className={legalUpdatedAtClass}>최종 업데이트: {updatedAt}</p>
+
+        <nav aria-label="목차" className={tocWrapClass}>
+          <p className={tocTitleClass}>목차</p>
+          <ol className={tocListClass}>
+            {tocItems.map((item, i) => (
+              <li key={item.id}>
+                <a href={`#${item.id}`} className={tocLinkClass}>
+                  {i + 1}. {item.label}
+                </a>
+              </li>
+            ))}
+          </ol>
+        </nav>
+
+        {children}
+      </div>
+    </div>
+  </main>
+);
+
+export default LegalPageLayout;

--- a/src/components/@shared/layout/LegalPageLayout/LegalPageLayout.types.ts
+++ b/src/components/@shared/layout/LegalPageLayout/LegalPageLayout.types.ts
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+export interface TocItem {
+  id: string;
+  label: string;
+}
+
+export interface LegalPageLayoutProps {
+  title: string;
+  updatedAt: string;
+  tocItems: TocItem[];
+  children: ReactNode;
+}

--- a/src/components/@shared/layout/LegalPageLayout/index.ts
+++ b/src/components/@shared/layout/LegalPageLayout/index.ts
@@ -1,0 +1,3 @@
+export { default as LegalPageLayout } from './LegalPageLayout';
+export * from './LegalPageLayout.styles';
+export type { TocItem } from './LegalPageLayout.types';

--- a/src/components/@shared/layout/SiteFooter/SiteFooter.styles.ts
+++ b/src/components/@shared/layout/SiteFooter/SiteFooter.styles.ts
@@ -4,6 +4,6 @@ export const footerBrandNameClass =
 export const footerDescClass = 'text-muted text-[12px]';
 
 export const footerLinkClass =
-  'text-muted hover:text-ink-2 text-[12px] font-medium max-[560px]:hidden';
+  'text-muted hover:text-ink-2 text-[12px] font-medium';
 
 export const footerCopyrightClass = 'text-muted text-[12px]';

--- a/src/components/@shared/layout/SiteFooter/SiteFooter.tsx
+++ b/src/components/@shared/layout/SiteFooter/SiteFooter.tsx
@@ -12,14 +12,12 @@ import {
 const SiteFooter = () => (
   <footer className="mt-16">
     <div className="mx-auto w-[min(880px,calc(100%-40px))] py-6">
-      <div className="flex items-center justify-between gap-x-6 gap-y-3 max-[560px]:flex-col max-[560px]:items-center">
-        <div className="flex items-center gap-5 max-[560px]:flex-col max-[560px]:items-center max-[560px]:gap-1">
-          <span className={footerBrandNameClass}>{SITE_NAME}</span>
-          <p className={footerDescClass}>
-            메가존 임직원을 위한 구내식당 메뉴 서비스
-          </p>
-        </div>
+      <div className="flex flex-col gap-3 min-[560px]:flex-row min-[560px]:items-center min-[560px]:justify-between">
         <div className="flex items-center gap-5">
+          <span className={footerBrandNameClass}>{SITE_NAME}</span>
+          <p className={footerDescClass}>메가존 직원을 위한 구내식당 메뉴 서비스</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
           {FOOTER_LINKS.map((l) => (
             <Link key={l.label} href={l.href} className={footerLinkClass}>
               {l.label}

--- a/src/components/@shared/layout/index.ts
+++ b/src/components/@shared/layout/index.ts
@@ -1,3 +1,4 @@
 export { default as SiteFooter } from './SiteFooter';
 export { default as SiteHeader } from './SiteHeader';
+export * from './LegalPageLayout';
 export { PageLayout } from './PageLayout';

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -7,4 +7,13 @@ export const NAV_ITEMS: NavItem[] = [
   { label: '공지사항', href: '/notice' },
 ];
 
-export const FOOTER_LINKS: { label: string; href: string }[] = [];
+export const FOOTER_LINKS: { label: string; href: string }[] = [
+  { label: '이용약관', href: '/terms' },
+  { label: '개인정보처리방침', href: '/privacy' },
+  { label: '문의', href: '/contact' },
+];
+
+export const CONTACTS: { name: string; email: string }[] = [
+  { name: '박서윤', email: 'dev.yelee@gmail.com' },
+  { name: '홍수혁', email: 'tngur1120@mz.co.kr' },
+];


### PR DESCRIPTION
## 개요

> **한줄 요약**: 이용약관·개인정보처리방침·문의 페이지를 추가하고 푸터·SEO 기반을 정비했습니다

비공식 사이드 프로젝트이지만 실 운영 서비스로서 최소한의 법적 고지와 개인정보 처리 안내가 필요했습니다.
문의 창구(`/contact`)도 함께 만들어 이용자가 제작자에게 직접 연락할 수 있도록 했습니다.
SEO 기반(`metadataBase`, `sitemap.ts`, `robots.ts`)도 함께 설정해 canonical URL이 올바르게 동작합니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **법적 페이지** | `terms/page.tsx`, `privacy/page.tsx` | 이용약관·개인정보처리방침 신규 생성 (TOC, 섹션, `/contact` 링크) |
| **문의 페이지** | `contact/page.tsx` | 이메일 카드 기반 문의 페이지 신규 생성 |
| **공유 레이아웃** | `LegalPageLayout/` | 법적 문서용 레이아웃 컴포넌트 (TOC, 섹션 스타일 일괄 제공) |
| **상수 관리** | `site.ts` | `CONTACTS` 배열 추가, `FOOTER_LINKS`에 문의 링크 추가 |
| **SEO 기반** | `layout.tsx`, `sitemap.ts`, `robots.ts` | `metadataBase` 설정, sitemap·robots 파일 신규 생성 |
| **푸터 개선** | `SiteFooter.tsx`, `SiteFooter.styles.ts` | 링크 항상 표시, 모바일 레이아웃 개선, "임직원" → "직원" 수정 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 이용자
    participant 약관 as /terms or /privacy
    participant 문의 as /contact
    participant 메일 as 메일 클라이언트

    이용자->>약관: 페이지 접근 (noindex)
    약관-->>이용자: TOC + 섹션 렌더
    이용자->>약관: "문의" 링크 클릭
    약관->>문의: /contact 이동
    문의-->>이용자: 연락처 카드 렌더 (박서윤, 홍수혁)
    이용자->>메일: 카드 클릭 → mailto 실행
```

&nbsp;

## 주요 리뷰 요청사항

- `CONTACTS` 배열의 이메일 주소가 맞는지 확인해 주세요 (`site.ts`)
- `/terms`, `/privacy`, `/contact` 모두 `robots: { index: false }` 처리했습니다 — 의도에 맞는지 확인 부탁드립니다

&nbsp;

## 테스트 계획

- [ ] `/terms` 접근 → TOC 앵커 스크롤 동작 확인
- [ ] `/privacy` 접근 → 테이블(제3자 제공) 렌더 확인
- [ ] `/contact` 접근 → 이메일 카드 클릭 시 메일 클라이언트 열림 확인
- [ ] 푸터 "문의" 링크 → `/contact` 이동 확인
- [ ] 모바일(375px) 푸터 링크 모두 표시 확인
- [ ] 기존 홈·공지사항 페이지 미영향 확인

---

> 🎭 **오늘의 커밋 시**
>
> 약관이란 건 아무도 안 읽지만 🙈
> 없으면 안 되는 법적 고지,
> 문의는 메일로 직접 때려라 📧
> sitemap도 챙겼으니 구글도 알겠지 🗺️

🤖 Generated with [Claude Code](https://claude.com/claude-code)