### PR TITLE
feat: [MEGA-52] 메가존 소식 페이지 /news — 네이버 뉴스 API 연동

### DIFF
--- a/src/api/news.ts
+++ b/src/api/news.ts
@@ -19,6 +19,7 @@ export const getNews = async (): Promise<NewsResult> => {
           'X-Naver-Client-Id': clientId,
           'X-Naver-Client-Secret': clientSecret,
         },
+        signal: AbortSignal.timeout(5000),
         next: { revalidate: 3600 },
       }
     );

--- a/src/api/news.ts
+++ b/src/api/news.ts
@@ -1,0 +1,40 @@
+import type { NaverNewsResponse, NewsItem } from '@/types/news';
+import { getSourceFromUrl, stripHtml } from '@/utils/newsFormat';
+
+export const getNews = async (): Promise<NewsItem[]> => {
+  const clientId = process.env.NAVER_CLIENT_ID;
+  const clientSecret = process.env.NAVER_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    // eslint-disable-next-line no-console
+    console.warn('[news] NAVER_CLIENT_ID or NAVER_CLIENT_SECRET not set');
+    return [];
+  }
+
+  try {
+    const res = await fetch(
+      'https://openapi.naver.com/v1/search/news.json?query=%EB%A9%94%EA%B0%80%EC%A1%B4%ED%81%B4%EB%9D%BC%EC%9A%B0%EB%93%9C&display=20&sort=date',
+      {
+        headers: {
+          'X-Naver-Client-Id': clientId,
+          'X-Naver-Client-Secret': clientSecret,
+        },
+        next: { revalidate: 3600 },
+      }
+    );
+
+    if (!res.ok) return [];
+
+    const data = (await res.json()) as NaverNewsResponse;
+
+    return data.items.map((item) => ({
+      title: stripHtml(item.title),
+      description: stripHtml(item.description),
+      originallink: item.originallink || item.link,
+      pubDate: item.pubDate,
+      source: getSourceFromUrl(item.originallink || item.link),
+    }));
+  } catch {
+    return [];
+  }
+};

--- a/src/api/news.ts
+++ b/src/api/news.ts
@@ -1,14 +1,14 @@
-import type { NaverNewsResponse, NewsItem } from '@/types/news';
+import type { NaverNewsResponse, NewsResult } from '@/types/news';
 import { getSourceFromUrl, stripHtml } from '@/utils/newsFormat';
 
-export const getNews = async (): Promise<NewsItem[]> => {
+export const getNews = async (): Promise<NewsResult> => {
   const clientId = process.env.NAVER_CLIENT_ID;
   const clientSecret = process.env.NAVER_CLIENT_SECRET;
 
   if (!clientId || !clientSecret) {
     // eslint-disable-next-line no-console
     console.warn('[news] NAVER_CLIENT_ID or NAVER_CLIENT_SECRET not set');
-    return [];
+    return { items: [], error: false };
   }
 
   try {
@@ -23,20 +23,23 @@ export const getNews = async (): Promise<NewsItem[]> => {
       }
     );
 
-    if (!res.ok) return [];
+    if (!res.ok) return { items: [], error: true };
 
     const data = (await res.json()) as NaverNewsResponse;
 
-    return (data.items ?? []).map((item) => ({
-      title: stripHtml(item.title),
-      description: stripHtml(item.description),
-      originallink: item.originallink || item.link,
-      pubDate: item.pubDate,
-      source: getSourceFromUrl(item.originallink || item.link),
-    }));
+    return {
+      items: (data.items ?? []).map((item) => ({
+        title: stripHtml(item.title),
+        description: stripHtml(item.description),
+        originallink: item.originallink || item.link,
+        pubDate: item.pubDate,
+        source: getSourceFromUrl(item.originallink || item.link),
+      })),
+      error: false,
+    };
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error('[news] Failed to fetch news:', err);
-    return [];
+    return { items: [], error: true };
   }
 };

--- a/src/api/news.ts
+++ b/src/api/news.ts
@@ -27,14 +27,16 @@ export const getNews = async (): Promise<NewsItem[]> => {
 
     const data = (await res.json()) as NaverNewsResponse;
 
-    return data.items.map((item) => ({
+    return (data.items ?? []).map((item) => ({
       title: stripHtml(item.title),
       description: stripHtml(item.description),
       originallink: item.originallink || item.link,
       pubDate: item.pubDate,
       source: getSourceFromUrl(item.originallink || item.link),
     }));
-  } catch {
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('[news] Failed to fetch news:', err);
     return [];
   }
 };

--- a/src/api/news.ts
+++ b/src/api/news.ts
@@ -13,7 +13,7 @@ export const getNews = async (): Promise<NewsItem[]> => {
 
   try {
     const res = await fetch(
-      'https://openapi.naver.com/v1/search/news.json?query=%EB%A9%94%EA%B0%80%EC%A1%B4&display=20&sort=date',
+      'https://openapi.naver.com/v1/search/news.json?query=%EB%A9%94%EA%B0%80%EC%A1%B4&display=100&sort=date',
       {
         headers: {
           'X-Naver-Client-Id': clientId,

--- a/src/api/news.ts
+++ b/src/api/news.ts
@@ -13,7 +13,7 @@ export const getNews = async (): Promise<NewsItem[]> => {
 
   try {
     const res = await fetch(
-      'https://openapi.naver.com/v1/search/news.json?query=%EB%A9%94%EA%B0%80%EC%A1%B4%ED%81%B4%EB%9D%BC%EC%9A%B0%EB%93%9C&display=20&sort=date',
+      'https://openapi.naver.com/v1/search/news.json?query=%EB%A9%94%EA%B0%80%EC%A1%B4&display=20&sort=date',
       {
         headers: {
           'X-Naver-Client-Id': clientId,

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -72,6 +72,10 @@ export const POST = async (req: NextRequest) => {
     return NextResponse.json({ error: 'invalid payload' }, { status: 400 });
   }
 
+  if (vote_type && !(['up', 'down'] as const).includes(vote_type as VoteType)) {
+    return NextResponse.json({ error: 'invalid vote_type' }, { status: 400 });
+  }
+
   try {
     const { error } = vote_type
       ? await supabaseServer.rpc('vote_or_switch', {

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -8,7 +8,7 @@ import { getBreadcrumbJsonLd } from '@/utils/jsonLd';
 
 export const revalidate = 3600;
 
-const newsDesc = `${SITE_NAME} 메가존클라우드 관련 최신 언론 기사 모음`;
+const newsDesc = `${SITE_NAME} 메가존 관련 최신 언론 기사 모음`;
 
 export const metadata: Metadata = {
   title: '소식',
@@ -40,8 +40,8 @@ export default async function NewsPage() {
       <SiteHeader />
       <PageLayout
         eyebrow="메가존 소식"
-        title="메가존클라우드 뉴스"
-        description="메가존클라우드 관련 최신 언론 기사를 모아봤어요"
+        title="메가존 뉴스"
+        description="메가존 관련 최신 언론 기사를 모아봤어요"
       >
         <NewsList items={items} />
       </PageLayout>

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
 };
 
 export default async function NewsPage() {
-  const items = await getNews();
+  const { items, error } = await getNews();
 
   return (
     <>
@@ -43,7 +43,7 @@ export default async function NewsPage() {
         title="메가존 뉴스"
         description="메가존 관련 최신 언론 기사를 모아봤어요"
       >
-        <NewsList items={items} />
+        <NewsList items={items} error={error} />
       </PageLayout>
       <SiteFooter />
     </>

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from 'next';
+
+import { getNews } from '@/api/news';
+import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
+import { NewsList } from '@/components/news';
+import { SITE_NAME } from '@/constants/site';
+import { getBreadcrumbJsonLd } from '@/utils/jsonLd';
+
+export const revalidate = 3600;
+
+const newsDesc = `${SITE_NAME} 메가존클라우드 관련 최신 언론 기사 모음`;
+
+export const metadata: Metadata = {
+  title: '소식',
+  description: newsDesc,
+  alternates: { canonical: '/news' },
+  openGraph: {
+    title: `소식 — ${SITE_NAME}`,
+    description: newsDesc,
+    url: '/news',
+  },
+};
+
+export default async function NewsPage() {
+  const items = await getNews();
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            getBreadcrumbJsonLd([
+              { name: '홈', path: '/' },
+              { name: '소식', path: '/news' },
+            ])
+          ),
+        }}
+      />
+      <SiteHeader />
+      <PageLayout
+        eyebrow="메가존 소식"
+        title="메가존클라우드 뉴스"
+        description="메가존클라우드 관련 최신 언론 기사를 모아봤어요"
+      >
+        <NewsList items={items} />
+      </PageLayout>
+      <SiteFooter />
+    </>
+  );
+}

--- a/src/components/news/NewsCard/NewsCard.styles.ts
+++ b/src/components/news/NewsCard/NewsCard.styles.ts
@@ -2,7 +2,9 @@ import { cn } from '@/utils/cn';
 
 export const cardWrapperClass = cn(
   'bg-surface shadow-[var(--shadow-card)] flex flex-col gap-2 px-5 py-4',
-  'cursor-pointer transition-shadow hover:shadow-[var(--shadow-card-hover)]'
+  'animate-[fadeUp_0.25s_ease_both] cursor-pointer',
+  'transition-[box-shadow,transform] hover:-translate-y-0.5 hover:shadow-[var(--shadow-card-hover)]',
+  'active:scale-[0.99]'
 );
 
 export const cardTitleClass =

--- a/src/components/news/NewsCard/NewsCard.styles.ts
+++ b/src/components/news/NewsCard/NewsCard.styles.ts
@@ -12,6 +12,3 @@ export const cardDescClass =
   'text-ink-2 text-[13px] leading-relaxed line-clamp-2 break-keep';
 
 export const cardMetaClass = 'text-muted text-[12px] flex items-center gap-2';
-
-export const cardLinkClass =
-  'text-muted text-[12px] underline-offset-2 hover:underline shrink-0';

--- a/src/components/news/NewsCard/NewsCard.styles.ts
+++ b/src/components/news/NewsCard/NewsCard.styles.ts
@@ -1,0 +1,17 @@
+import { cn } from '@/utils/cn';
+
+export const cardWrapperClass = cn(
+  'bg-surface shadow-[var(--shadow-card)] flex flex-col gap-2 px-5 py-4',
+  'transition-shadow hover:shadow-[var(--shadow-card-hover)]'
+);
+
+export const cardTitleClass =
+  'text-ink text-[14px] font-bold leading-snug line-clamp-1 break-keep';
+
+export const cardDescClass =
+  'text-ink-2 text-[13px] leading-relaxed line-clamp-2 break-keep';
+
+export const cardMetaClass = 'text-muted text-[12px] flex items-center gap-2';
+
+export const cardLinkClass =
+  'text-muted text-[12px] underline-offset-2 hover:underline shrink-0';

--- a/src/components/news/NewsCard/NewsCard.styles.ts
+++ b/src/components/news/NewsCard/NewsCard.styles.ts
@@ -1,16 +1,32 @@
 import { cn } from '@/utils/cn';
 
-export const cardWrapperClass = cn(
-  'bg-surface shadow-[var(--shadow-card)] flex flex-col gap-2 px-5 py-4',
+const base = cn(
   'animate-[fadeUp_0.25s_ease_both] cursor-pointer',
   'transition-[box-shadow,transform] hover:-translate-y-0.5 hover:shadow-[var(--shadow-card-hover)]',
   'active:scale-[0.99]'
 );
 
-export const cardTitleClass =
-  'text-ink text-[14px] font-bold leading-snug line-clamp-1 break-keep';
+export const featuredWrapperClass = cn(
+  'bg-surface shadow-[var(--shadow-card)] flex flex-col gap-[10px] py-5 pr-5 pl-[17px]',
+  '[border-left:3px_solid_var(--color-accent)]',
+  base
+);
 
-export const cardDescClass =
-  'text-ink-2 text-[13px] leading-relaxed line-clamp-2 break-keep';
+export const compactWrapperClass = cn(
+  'bg-surface shadow-[var(--shadow-card)] flex flex-col gap-1 px-5 py-3',
+  base
+);
 
-export const cardMetaClass = 'text-muted text-[12px] flex items-center gap-2';
+export const sourceChipClass =
+  'bg-surface-warm text-ink-2 text-[11px] font-semibold px-2 py-0.5 w-fit tracking-[0.03em]';
+
+export const featuredTitleClass =
+  'text-ink text-[17px] font-extrabold leading-snug tracking-[-0.02em] break-keep';
+
+export const featuredDescClass =
+  'text-ink-2 text-[13px] leading-relaxed line-clamp-3 break-keep';
+
+export const compactTitleClass =
+  'text-ink text-[13.5px] font-bold leading-snug line-clamp-1 break-keep';
+
+export const cardMetaClass = 'text-muted text-[11.5px] flex items-center gap-2';

--- a/src/components/news/NewsCard/NewsCard.styles.ts
+++ b/src/components/news/NewsCard/NewsCard.styles.ts
@@ -2,7 +2,7 @@ import { cn } from '@/utils/cn';
 
 export const cardWrapperClass = cn(
   'bg-surface shadow-[var(--shadow-card)] flex flex-col gap-2 px-5 py-4',
-  'transition-shadow hover:shadow-[var(--shadow-card-hover)]'
+  'cursor-pointer transition-shadow hover:shadow-[var(--shadow-card-hover)]'
 );
 
 export const cardTitleClass =

--- a/src/components/news/NewsCard/NewsCard.tsx
+++ b/src/components/news/NewsCard/NewsCard.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link';
 
 import dayjs from '@/lib/dayjs';
-import type { NewsItem } from '@/types/news';
 
 import {
   cardDescClass,
@@ -10,11 +9,7 @@ import {
   cardTitleClass,
   cardWrapperClass,
 } from './NewsCard.styles';
-
-type Props = Pick<
-  NewsItem,
-  'title' | 'description' | 'originallink' | 'pubDate' | 'source'
->;
+import type { NewsCardProps } from './NewsCard.types';
 
 const NewsCard = ({
   title,
@@ -22,24 +17,22 @@ const NewsCard = ({
   originallink,
   pubDate,
   source,
-}: Props) => (
-  <article className={cardWrapperClass}>
+}: NewsCardProps) => (
+  <Link
+    href={originallink}
+    target="_blank"
+    rel="noopener noreferrer"
+    className={cardWrapperClass}
+  >
     <p className={cardTitleClass}>{title}</p>
     <p className={cardDescClass}>{description}</p>
     <div className={cardMetaClass}>
       <span>{source}</span>
       <span aria-hidden>·</span>
       <span>{dayjs(pubDate).tz().format('YYYY.MM.DD')}</span>
-      <Link
-        href={originallink}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={cardLinkClass}
-      >
-        원문 →
-      </Link>
+      <span className={cardLinkClass}>원문 →</span>
     </div>
-  </article>
+  </Link>
 );
 
 export default NewsCard;

--- a/src/components/news/NewsCard/NewsCard.tsx
+++ b/src/components/news/NewsCard/NewsCard.tsx
@@ -1,12 +1,15 @@
 import Link from 'next/link';
 
-import dayjs from '@/lib/dayjs';
+import { getRelativeTime } from '@/utils/newsFormat';
 
 import {
-  cardDescClass,
   cardMetaClass,
-  cardTitleClass,
-  cardWrapperClass,
+  compactTitleClass,
+  compactWrapperClass,
+  featuredDescClass,
+  featuredTitleClass,
+  featuredWrapperClass,
+  sourceChipClass,
 } from './NewsCard.styles';
 import type { NewsCardProps } from './NewsCard.types';
 
@@ -16,21 +19,41 @@ const NewsCard = ({
   originallink,
   pubDate,
   source,
-}: NewsCardProps) => (
-  <Link
-    href={originallink}
-    target="_blank"
-    rel="noopener noreferrer"
-    className={cardWrapperClass}
-  >
-    <p className={cardTitleClass}>{title}</p>
-    <p className={cardDescClass}>{description}</p>
-    <div className={cardMetaClass}>
-      <span>{source}</span>
-      <span aria-hidden>·</span>
-      <span>{dayjs(pubDate).tz().format('YYYY.MM.DD')}</span>
-    </div>
-  </Link>
-);
+  variant,
+}: NewsCardProps) => {
+  const relativeTime = getRelativeTime(pubDate);
+
+  if (variant === 'compact') {
+    return (
+      <Link
+        href={originallink}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={compactWrapperClass}
+      >
+        <p className={compactTitleClass}>{title}</p>
+        <div className={cardMetaClass}>
+          <span>{source}</span>
+          <span aria-hidden>·</span>
+          <span>{relativeTime}</span>
+        </div>
+      </Link>
+    );
+  }
+
+  return (
+    <Link
+      href={originallink}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={featuredWrapperClass}
+    >
+      <span className={sourceChipClass}>{source}</span>
+      <p className={featuredTitleClass}>{title}</p>
+      <p className={featuredDescClass}>{description}</p>
+      <span className={cardMetaClass}>{relativeTime}</span>
+    </Link>
+  );
+};
 
 export default NewsCard;

--- a/src/components/news/NewsCard/NewsCard.tsx
+++ b/src/components/news/NewsCard/NewsCard.tsx
@@ -4,7 +4,6 @@ import dayjs from '@/lib/dayjs';
 
 import {
   cardDescClass,
-  cardLinkClass,
   cardMetaClass,
   cardTitleClass,
   cardWrapperClass,
@@ -30,7 +29,6 @@ const NewsCard = ({
       <span>{source}</span>
       <span aria-hidden>·</span>
       <span>{dayjs(pubDate).tz().format('YYYY.MM.DD')}</span>
-      <span className={cardLinkClass}>원문 →</span>
     </div>
   </Link>
 );

--- a/src/components/news/NewsCard/NewsCard.tsx
+++ b/src/components/news/NewsCard/NewsCard.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link';
+
+import dayjs from '@/lib/dayjs';
+import type { NewsItem } from '@/types/news';
+
+import {
+  cardDescClass,
+  cardLinkClass,
+  cardMetaClass,
+  cardTitleClass,
+  cardWrapperClass,
+} from './NewsCard.styles';
+
+type Props = Pick<
+  NewsItem,
+  'title' | 'description' | 'originallink' | 'pubDate' | 'source'
+>;
+
+const NewsCard = ({
+  title,
+  description,
+  originallink,
+  pubDate,
+  source,
+}: Props) => (
+  <article className={cardWrapperClass}>
+    <p className={cardTitleClass}>{title}</p>
+    <p className={cardDescClass}>{description}</p>
+    <div className={cardMetaClass}>
+      <span>{source}</span>
+      <span aria-hidden>·</span>
+      <span>{dayjs(pubDate).tz().format('YYYY.MM.DD')}</span>
+      <Link
+        href={originallink}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cardLinkClass}
+      >
+        원문 →
+      </Link>
+    </div>
+  </article>
+);
+
+export default NewsCard;

--- a/src/components/news/NewsCard/NewsCard.types.ts
+++ b/src/components/news/NewsCard/NewsCard.types.ts
@@ -1,0 +1,6 @@
+import type { NewsItem } from '@/types/news';
+
+export type NewsCardProps = Pick<
+  NewsItem,
+  'title' | 'description' | 'originallink' | 'pubDate' | 'source'
+>;

--- a/src/components/news/NewsCard/NewsCard.types.ts
+++ b/src/components/news/NewsCard/NewsCard.types.ts
@@ -3,4 +3,4 @@ import type { NewsItem } from '@/types/news';
 export type NewsCardProps = Pick<
   NewsItem,
   'title' | 'description' | 'originallink' | 'pubDate' | 'source'
->;
+> & { variant: 'featured' | 'compact' };

--- a/src/components/news/NewsCard/index.ts
+++ b/src/components/news/NewsCard/index.ts
@@ -1,0 +1,1 @@
+export { default as NewsCard } from './NewsCard';

--- a/src/components/news/NewsList/NewsList.styles.ts
+++ b/src/components/news/NewsList/NewsList.styles.ts
@@ -1,2 +1,2 @@
 export const loadMoreClass =
-  'text-muted border-ink/10 hover:bg-ink/5 mt-2 w-full border py-3 text-[13px] transition-colors';
+  'text-muted bg-surface-warm hover:bg-line mt-2 w-full py-3 text-[13px] transition-colors';

--- a/src/components/news/NewsList/NewsList.styles.ts
+++ b/src/components/news/NewsList/NewsList.styles.ts
@@ -2,7 +2,7 @@ export const loadMoreClass =
   'text-muted bg-surface-warm hover:bg-line mt-2 w-full py-3 text-[13px] transition-[background-color,transform] active:scale-[0.98]';
 
 export const emptyStateClass =
-  'flex flex-col items-center gap-2 py-16 text-center';
+  'flex w-full flex-col items-center gap-2 py-16 text-center';
 
 export const emptyTitleClass = 'text-ink-2 text-[14px] font-semibold';
 

--- a/src/components/news/NewsList/NewsList.styles.ts
+++ b/src/components/news/NewsList/NewsList.styles.ts
@@ -1,0 +1,2 @@
+export const loadMoreClass =
+  'text-muted border-ink/10 hover:bg-ink/5 mt-2 w-full border py-3 text-[13px] transition-colors';

--- a/src/components/news/NewsList/NewsList.styles.ts
+++ b/src/components/news/NewsList/NewsList.styles.ts
@@ -1,5 +1,5 @@
 export const loadMoreClass =
-  'text-muted bg-surface-warm hover:bg-line mt-2 w-full py-3 text-[13px] transition-[background-color,transform] active:scale-[0.98]';
+  'text-ink-2 font-semibold bg-surface-warm hover:bg-line mt-2 w-full py-3 text-[13px] transition-[background-color,transform] active:scale-[0.98]';
 
 export const emptyStateClass =
   'flex w-full flex-col items-center gap-2 py-16 text-center';

--- a/src/components/news/NewsList/NewsList.styles.ts
+++ b/src/components/news/NewsList/NewsList.styles.ts
@@ -1,2 +1,9 @@
 export const loadMoreClass =
   'text-muted bg-surface-warm hover:bg-line mt-2 w-full py-3 text-[13px] transition-[background-color,transform] active:scale-[0.98]';
+
+export const emptyStateClass =
+  'flex flex-col items-center gap-2 py-16 text-center';
+
+export const emptyTitleClass = 'text-ink-2 text-[14px] font-semibold';
+
+export const emptyDescClass = 'text-muted text-[13px]';

--- a/src/components/news/NewsList/NewsList.styles.ts
+++ b/src/components/news/NewsList/NewsList.styles.ts
@@ -1,2 +1,2 @@
 export const loadMoreClass =
-  'text-muted bg-surface-warm hover:bg-line mt-2 w-full py-3 text-[13px] transition-colors';
+  'text-muted bg-surface-warm hover:bg-line mt-2 w-full py-3 text-[13px] transition-[background-color,transform] active:scale-[0.98]';

--- a/src/components/news/NewsList/NewsList.tsx
+++ b/src/components/news/NewsList/NewsList.tsx
@@ -16,7 +16,10 @@ const NewsList = ({ items }: Props) => {
   return (
     <div className="flex flex-col gap-3">
       {items.map((item) => (
-        <NewsCard key={item.originallink} {...item} />
+        <NewsCard
+          key={item.originallink || item.pubDate + item.title}
+          {...item}
+        />
       ))}
     </div>
   );

--- a/src/components/news/NewsList/NewsList.tsx
+++ b/src/components/news/NewsList/NewsList.tsx
@@ -3,28 +3,43 @@
 import { useState } from 'react';
 
 import { NewsCard } from '../NewsCard';
-import { loadMoreClass } from './NewsList.styles';
+import {
+  emptyDescClass,
+  emptyStateClass,
+  emptyTitleClass,
+  loadMoreClass,
+} from './NewsList.styles';
 import type { NewsListProps } from './NewsList.types';
 
 const PAGE_SIZE = 20;
 
-const NewsList = ({ items }: NewsListProps) => {
+const NewsList = ({ items, error }: NewsListProps) => {
   const [visible, setVisible] = useState(PAGE_SIZE);
+
+  if (error) {
+    return (
+      <div className={emptyStateClass}>
+        <p className={emptyTitleClass}>소식을 불러오지 못했어요</p>
+        <p className={emptyDescClass}>잠시 후 다시 시도해주세요</p>
+      </div>
+    );
+  }
 
   if (items.length === 0) {
     return (
-      <p className="text-muted py-12 text-center text-[14px]">
-        소식을 불러오지 못했어요
-      </p>
+      <div className={emptyStateClass}>
+        <p className={emptyTitleClass}>아직 소식이 없어요</p>
+      </div>
     );
   }
 
   return (
     <div className="flex flex-col gap-3">
-      {items.slice(0, visible).map((item) => (
+      {items.slice(0, visible).map((item, idx) => (
         <NewsCard
           key={item.originallink || item.pubDate + item.title}
           {...item}
+          variant={idx === 0 ? 'featured' : 'compact'}
         />
       ))}
       {visible < items.length && (

--- a/src/components/news/NewsList/NewsList.tsx
+++ b/src/components/news/NewsList/NewsList.tsx
@@ -1,0 +1,25 @@
+import type { NewsItem } from '@/types/news';
+
+import { NewsCard } from '../NewsCard';
+
+type Props = { items: NewsItem[] };
+
+const NewsList = ({ items }: Props) => {
+  if (items.length === 0) {
+    return (
+      <p className="text-muted py-12 text-center text-[14px]">
+        소식을 불러오지 못했어요
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {items.map((item) => (
+        <NewsCard key={item.originallink} {...item} />
+      ))}
+    </div>
+  );
+};
+
+export default NewsList;

--- a/src/components/news/NewsList/NewsList.tsx
+++ b/src/components/news/NewsList/NewsList.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 
 import { NewsCard } from '../NewsCard';
+
 import {
   emptyDescClass,
   emptyStateClass,

--- a/src/components/news/NewsList/NewsList.tsx
+++ b/src/components/news/NewsList/NewsList.tsx
@@ -1,10 +1,16 @@
-import type { NewsItem } from '@/types/news';
+'use client';
+
+import { useState } from 'react';
 
 import { NewsCard } from '../NewsCard';
+import { loadMoreClass } from './NewsList.styles';
+import type { NewsListProps } from './NewsList.types';
 
-type Props = { items: NewsItem[] };
+const PAGE_SIZE = 20;
 
-const NewsList = ({ items }: Props) => {
+const NewsList = ({ items }: NewsListProps) => {
+  const [visible, setVisible] = useState(PAGE_SIZE);
+
   if (items.length === 0) {
     return (
       <p className="text-muted py-12 text-center text-[14px]">
@@ -15,12 +21,21 @@ const NewsList = ({ items }: Props) => {
 
   return (
     <div className="flex flex-col gap-3">
-      {items.map((item) => (
+      {items.slice(0, visible).map((item) => (
         <NewsCard
           key={item.originallink || item.pubDate + item.title}
           {...item}
         />
       ))}
+      {visible < items.length && (
+        <button
+          type="button"
+          className={loadMoreClass}
+          onClick={() => setVisible((v) => v + PAGE_SIZE)}
+        >
+          더 보기 ({items.length - visible}개 남음)
+        </button>
+      )}
     </div>
   );
 };

--- a/src/components/news/NewsList/NewsList.types.ts
+++ b/src/components/news/NewsList/NewsList.types.ts
@@ -1,0 +1,3 @@
+import type { NewsItem } from '@/types/news';
+
+export type NewsListProps = { items: NewsItem[] };

--- a/src/components/news/NewsList/NewsList.types.ts
+++ b/src/components/news/NewsList/NewsList.types.ts
@@ -1,3 +1,3 @@
 import type { NewsItem } from '@/types/news';
 
-export type NewsListProps = { items: NewsItem[] };
+export type NewsListProps = { items: NewsItem[]; error?: boolean };

--- a/src/components/news/NewsList/index.ts
+++ b/src/components/news/NewsList/index.ts
@@ -1,0 +1,1 @@
+export { default as NewsList } from './NewsList';

--- a/src/components/news/index.ts
+++ b/src/components/news/index.ts
@@ -1,0 +1,2 @@
+export * from './NewsCard';
+export * from './NewsList';

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -4,6 +4,7 @@ export const SITE_NAME = 'MegaBobs';
 
 export const NAV_ITEMS: NavItem[] = [
   { label: '식단표', href: '/' },
+  { label: '소식', href: '/news' },
   { label: '공지사항', href: '/notice' },
   { label: '미니게임', href: '/games' },
 ];

--- a/src/hooks/useVote.ts
+++ b/src/hooks/useVote.ts
@@ -109,7 +109,7 @@ export const useVotes = (date: string, { enabled = true } = {}) => {
           body: JSON.stringify({
             menu_key: menuKey,
             vote_type: isSame ? null : voteType,
-            date: menuKey.split('_')[0],
+            date,
           }),
         });
         if (!res.ok) throw new Error('vote failed');

--- a/src/types/news.ts
+++ b/src/types/news.ts
@@ -1,7 +1,7 @@
 // src/types/news.ts
 export type NaverNewsItem = {
   title: string;
-  originallink: string;
+  originallink: string | undefined;
   link: string;
   description: string;
   pubDate: string;

--- a/src/types/news.ts
+++ b/src/types/news.ts
@@ -18,3 +18,5 @@ export type NewsItem = {
   pubDate: string;
   source: string;
 };
+
+export type NewsResult = { items: NewsItem[]; error: boolean };

--- a/src/types/news.ts
+++ b/src/types/news.ts
@@ -1,0 +1,20 @@
+// src/types/news.ts
+export type NaverNewsItem = {
+  title: string;
+  originallink: string;
+  link: string;
+  description: string;
+  pubDate: string;
+};
+
+export type NaverNewsResponse = {
+  items: NaverNewsItem[];
+};
+
+export type NewsItem = {
+  title: string;
+  description: string;
+  originallink: string;
+  pubDate: string;
+  source: string;
+};

--- a/src/utils/newsFormat.ts
+++ b/src/utils/newsFormat.ts
@@ -27,10 +27,14 @@ export const stripHtml = (html: string): string =>
     .replace(/&lsquo;/g, "'")
     .replace(/&rdquo;/g, '"')
     .replace(/&ldquo;/g, '"')
-    .replace(/&#x([0-9a-fA-F]+);/gi, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16))
-    )
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)));
+    .replace(/&#x([0-9a-fA-F]+);/gi, (match, hex) => {
+      const cp = parseInt(hex, 16);
+      return cp <= 0x10ffff ? String.fromCodePoint(cp) : match;
+    })
+    .replace(/&#(\d+);/g, (match, dec) => {
+      const cp = parseInt(dec, 10);
+      return cp <= 0x10ffff ? String.fromCodePoint(cp) : match;
+    });
 
 export const getSourceFromUrl = (url: string): string => {
   try {

--- a/src/utils/newsFormat.ts
+++ b/src/utils/newsFormat.ts
@@ -1,3 +1,20 @@
+import dayjs from '@/lib/dayjs';
+
+export const getRelativeTime = (pubDate: string): string => {
+  const pub = dayjs(pubDate).tz();
+  const now = dayjs().tz();
+  const diffMin = now.diff(pub, 'minute');
+  const diffHour = now.diff(pub, 'hour');
+  const diffDay = now.diff(pub, 'day');
+
+  if (diffMin < 1) return '방금';
+  if (diffMin < 60) return `${diffMin}분 전`;
+  if (diffHour < 24) return `${diffHour}시간 전`;
+  if (diffDay === 1) return '어제';
+  if (diffDay < 7) return `${diffDay}일 전`;
+  return pub.format('MM.DD');
+};
+
 export const stripHtml = (html: string): string =>
   html
     .replace(/<[^>]*>/g, '')

--- a/src/utils/newsFormat.ts
+++ b/src/utils/newsFormat.ts
@@ -1,0 +1,16 @@
+export const stripHtml = (html: string): string =>
+  html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&#\d+;/g, '');
+
+export const getSourceFromUrl = (url: string): string => {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return '';
+  }
+};

--- a/src/utils/newsFormat.ts
+++ b/src/utils/newsFormat.ts
@@ -5,6 +5,12 @@ export const stripHtml = (html: string): string =>
     .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&rsquo;/g, "'")
+    .replace(/&lsquo;/g, "'")
+    .replace(/&rdquo;/g, '"')
+    .replace(/&ldquo;/g, '"')
+    .replace(/&#x[0-9a-fA-F]+;/gi, '')
     .replace(/&#\d+;/g, '');
 
 export const getSourceFromUrl = (url: string): string => {

--- a/src/utils/newsFormat.ts
+++ b/src/utils/newsFormat.ts
@@ -27,8 +27,10 @@ export const stripHtml = (html: string): string =>
     .replace(/&lsquo;/g, "'")
     .replace(/&rdquo;/g, '"')
     .replace(/&ldquo;/g, '"')
-    .replace(/&#x[0-9a-fA-F]+;/gi, '')
-    .replace(/&#\d+;/g, '');
+    .replace(/&#x([0-9a-fA-F]+);/gi, (_, hex) =>
+      String.fromCodePoint(parseInt(hex, 16))
+    )
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(parseInt(dec, 10)));
 
 export const getSourceFromUrl = (url: string): string => {
   try {


### PR DESCRIPTION
## 개요

> **한줄 요약**: 네이버 뉴스 Open API로 메가존 관련 소식을 실시간 수집해 보여주는 `/news` 페이지를 추가합니다.

메가존 임직원이 회사 관련 뉴스를 외부 검색 없이 식당 앱에서 바로 확인할 수 있도록 소식 페이지를 구현합니다.
ISR 1시간 캐싱으로 서버 부담 최소화, 크리덴셜 없는 환경에서는 graceful degradation(빈 상태)으로 처리합니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
|---|---|---|
| **뉴스 API** | `news.ts`, `newsFormat.ts` | 네이버 Open API fetch, HTML 엔티티 디코딩, 출처 파싱 |
| **타입** | `news.ts` (types) | `NewsItem`, `NewsResult`, `NaverNewsResponse` 타입 정의 |
| **페이지** | `app/news/page.tsx` | ISR 1h, 서버에서 fetch → `NewsList`로 전달 |
| **NewsCard** | `NewsCard.tsx`, `.styles.ts`, `.types.ts` | featured(첫 번째) / compact 변형, 전체 클릭 영역 |
| **NewsList** | `NewsList.tsx`, `.styles.ts`, `.types.ts` | 20개씩 더 보기, 에러·빈 상태 처리 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 브라우저
    participant 페이지(ISR)
    participant 네이버API

    브라우저->>페이지(ISR): GET /news
    페이지(ISR)->>네이버API: query=메가존&display=100&sort=date
    네이버API-->>페이지(ISR): NewsItem[] (HTML 포함)
    페이지(ISR)->>페이지(ISR): stripHtml() / getRelativeTime()
    페이지(ISR)-->>브라우저: NewsCard 목록 렌더
    브라우저->>브라우저: 더 보기 클릭 → 20개씩 추가 노출
```

&nbsp;

## 테스트 계획

- [ ] `/news` 접속 시 카드 목록 정상 렌더 확인
- [ ] Featured(첫 번째) 카드 좌측 액센트 바 표시 확인
- [ ] 더 보기 버튼으로 20개씩 추가 로드 확인
- [ ] NAVER 크리덴셜 미설정 시 빈 상태(에러 없음) 확인
- [ ] 카드 클릭 → 원문 링크로 새 탭 이동 확인
- [ ] 기존 `/`, `/games`, `/notice` 등 기존 페이지 미영향 확인

---

> 🎭 **오늘의 커밋 시**
>
> 뉴스를 찾아 헤매던 임직원들이여 🔍
> 이제 밥 먹으러 가기 전 한 번만 보면 돼 📰
> 네이버가 긁어오고, ISR이 캐싱하고 ⚡
> 엔티티 디코딩으로 `&#x27;`는 이제 안녕 👋
> 소식 한 줄에 하루가 더 풍요로워진다 🌱

🤖 Generated with [Claude Code](https://claude.com/claude-code)