### PR TITLE
chore: Vercel 배포 보호 bypass SW 추가 및 리스너 누수 수정

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,27 @@
+let bypassToken = null;
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data?.type === 'SET_BYPASS') {
+    bypassToken = event.data.token;
+  }
+});
+
+self.addEventListener('fetch', (event) => {
+  if (!bypassToken) return;
+
+  const url = new URL(event.request.url);
+  if (url.origin !== self.location.origin) return;
+
+  const headers = new Headers(event.request.headers);
+  headers.set('x-vercel-protection-bypass', bypassToken);
+
+  event.respondWith(fetch(new Request(event.request, { headers })));
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from 'react-hot-toast';
 
 import './globals.css';
 
+import VercelBypassSW from '@/components/@shared/VercelBypassSW';
 import { SITE_NAME } from '@/constants/site';
 import { SITE_DESC } from '@/utils/jsonLd';
 
@@ -106,6 +107,7 @@ export default function RootLayout({
           }}
         />
         {process.env.VERCEL_ENV && <Analytics />}
+        <VercelBypassSW />
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -107,7 +107,7 @@ export default function RootLayout({
           }}
         />
         {process.env.VERCEL_ENV && <Analytics />}
-        <VercelBypassSW />
+        {process.env.VERCEL_ENV !== 'production' && <VercelBypassSW />}
       </body>
     </html>
   );

--- a/src/components/@shared/VercelBypassSW.tsx
+++ b/src/components/@shared/VercelBypassSW.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const BYPASS_KEY = 'vbp';
+const BYPASS_PARAM = 'x-vercel-protection-bypass';
+
+const sendToken = (token: string) => {
+  navigator.serviceWorker.controller?.postMessage({ type: 'SET_BYPASS', token });
+};
+
+const VercelBypassSW = () => {
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) return;
+
+    const params = new URLSearchParams(window.location.search);
+    const urlToken = params.get(BYPASS_PARAM);
+    const token = urlToken ?? sessionStorage.getItem(BYPASS_KEY);
+
+    if (!token) return;
+    if (urlToken) sessionStorage.setItem(BYPASS_KEY, urlToken);
+
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      sendToken(token);
+    });
+
+    navigator.serviceWorker.register('/sw.js').then(() => {
+      sendToken(token);
+
+      if (urlToken) {
+        navigator.serviceWorker.ready.then(() => {
+          const url = new URL(window.location.href);
+          url.searchParams.delete(BYPASS_PARAM);
+          window.location.replace(url.toString());
+        });
+      }
+    });
+  }, []);
+
+  return null;
+};
+
+export default VercelBypassSW;

--- a/src/components/@shared/VercelBypassSW.tsx
+++ b/src/components/@shared/VercelBypassSW.tsx
@@ -20,9 +20,8 @@ const VercelBypassSW = () => {
     if (!token) return;
     if (urlToken) sessionStorage.setItem(BYPASS_KEY, urlToken);
 
-    navigator.serviceWorker.addEventListener('controllerchange', () => {
-      sendToken(token);
-    });
+    const onControllerChange = () => sendToken(token);
+    navigator.serviceWorker.addEventListener('controllerchange', onControllerChange);
 
     navigator.serviceWorker.register('/sw.js').then(() => {
       sendToken(token);
@@ -35,6 +34,10 @@ const VercelBypassSW = () => {
         });
       }
     });
+
+    return () => {
+      navigator.serviceWorker.removeEventListener('controllerchange', onControllerChange);
+    };
   }, []);
 
   return null;


### PR DESCRIPTION
## 개요

> **한줄 요약**: Vercel 배포 보호(Protection) 우회를 위한 Service Worker 추가

Vercel 배포 보호가 활성화된 Preview/Development 환경에서 `x-vercel-protection-bypass` 토큰을 URL 파라미터로 전달받아 이후 모든 요청 헤더에 자동으로 주입하는 Service Worker를 도입합니다. 토큰은 sessionStorage에 보존되어 페이지 이동 시에도 유지되며, 프로덕션 환경에서는 컴포넌트 자체가 제외됩니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **Service Worker** | `sw.js` | bypass 토큰을 수신해 동일 출처 fetch 요청 헤더에 주입 |
| **React 컴포넌트** | `VercelBypassSW.tsx` | SW 등록·토큰 전달·URL 정리 처리 (non-production only) |
| **레이아웃** | `layout.tsx` | VERCEL_ENV 가드로 프로덕션 제외 후 컴포넌트 마운트 |

&nbsp;

🎭 오늘의 커밋 시

🛡️ 파라미터로 들어온 토큰 한 장,
SW가 받아 조용히 헤더에 심네
프리뷰 문 앞 경비원 눈 피해
이제 bypass, 두 손 모아 통과 🙌

&nbsp;

🤖 Generated with [Claude Code](https://claude.com/claude-code)