### PR TITLE
feat: [메가존 소식] 회사별 필터 탭·더보기 페이지네이션 추가 및 NewsCard UI 개선

### DIFF
--- a/src/api/getNews.ts
+++ b/src/api/getNews.ts
@@ -12,6 +12,12 @@ type NewsRow = {
   published_at: string;
 };
 
+type GetNewsOptions = {
+  limit?: number;
+  offset?: number;
+  company?: NewsCompany;
+};
+
 const toCompanyNews = (row: NewsRow): CompanyNews => ({
   url: row.url,
   title: row.title,
@@ -21,16 +27,22 @@ const toCompanyNews = (row: NewsRow): CompanyNews => ({
   publishedAt: row.published_at,
 });
 
-/**
- * Supabase `company_news` 테이블에서 최신 뉴스를 조회한다.
- * @param limit - 최대 조회 건수 (기본 30)
- */
-const getNews = async (limit = 30): Promise<CompanyNews[]> => {
-  const { data, error } = await supabaseServer
+const getNews = async ({
+  limit = 20,
+  offset = 0,
+  company,
+}: GetNewsOptions = {}): Promise<CompanyNews[]> => {
+  let query = supabaseServer
     .from('company_news')
     .select('url, title, summary, source, company, published_at')
     .order('published_at', { ascending: false })
-    .limit(limit);
+    .range(offset, offset + limit - 1);
+
+  if (company) {
+    query = query.eq('company', company);
+  }
+
+  const { data, error } = await query;
 
   if (error) {
     // 테이블 미생성(42P01)은 빈 상태로 강등 — 배포가 수동 SQL 실행 순서에 묶이지 않도록

--- a/src/api/getNews.ts
+++ b/src/api/getNews.ts
@@ -58,4 +58,16 @@ const getNews = async ({
   return (data ?? []).map(toCompanyNews);
 };
 
+export const getLastCrawledAt = async (): Promise<string | null> => {
+  const { data, error } = await supabaseServer
+    .from('company_news')
+    .select('created_at')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (error) return null;
+  return data?.created_at ?? null;
+};
+
 export default getNews;

--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest } from 'next/server';
+
+import getNews from '@/api/getNews';
+import type { NewsCompany } from '@/models/news';
+
+const VALID_COMPANIES = new Set<string>([
+  'megazone',
+  'megazonecloud',
+  'megazonesoft',
+]);
+
+const json = (body: unknown, status: number) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+export const GET = async (req: NextRequest) => {
+  const { searchParams } = new URL(req.url);
+  const companyParam = searchParams.get('company');
+  const offsetParam = searchParams.get('offset');
+  const limitParam = searchParams.get('limit');
+
+  const company =
+    companyParam && VALID_COMPANIES.has(companyParam)
+      ? (companyParam as NewsCompany)
+      : undefined;
+  const offset = Math.max(0, Number(offsetParam) || 0);
+  const limit = Math.min(50, Math.max(1, Number(limitParam) || 20));
+
+  try {
+    const data = await getNews({ company, offset, limit });
+    return json(data, 200);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : 'Internal error';
+    return json({ error }, 500);
+  }
+};

--- a/src/app/news/page.styles.ts
+++ b/src/app/news/page.styles.ts
@@ -1,8 +1,8 @@
-export const newsFootnoteClass = 'text-muted pt-1.5 text-center text-xs';
+export const emptyNewsClass =
+  'flex flex-col items-center gap-3 px-1 py-24 text-center';
 
-export const emptyNewsClass = 'border-t-ink border-t-2 px-1 py-16 text-center';
+export const emptyNewsIconClass = 'text-line size-12';
 
-export const emptyNewsSoonClass =
-  'text-muted text-2xl font-extrabold tracking-[0.2em]';
+export const emptyNewsTitleClass = 'text-ink-2 text-[17px] font-extrabold';
 
-export const emptyNewsDescClass = 'text-muted mt-3 text-[13.5px]';
+export const emptyNewsDescClass = 'text-muted text-[13.5px]';

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,16 +1,18 @@
 import type { Metadata } from 'next';
 
+import { Newspaper } from 'lucide-react';
+
 import getNews from '@/api/getNews';
 import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
-import NewsCard from '@/components/news/NewsCard';
+import NewsFilter from '@/components/news/NewsFilter';
 import { SITE_NAME } from '@/constants/site';
 import { getBreadcrumbJsonLd } from '@/utils/jsonLd';
 
 import {
   emptyNewsClass,
   emptyNewsDescClass,
-  emptyNewsSoonClass,
-  newsFootnoteClass,
+  emptyNewsIconClass,
+  emptyNewsTitleClass,
 } from './page.styles';
 
 const newsDesc =
@@ -30,7 +32,14 @@ export const metadata: Metadata = {
 export const revalidate = 21600;
 
 export default async function NewsPage() {
-  const news = await getNews();
+  const [all, megazone, megazonecloud, megazonesoft] = await Promise.all([
+    getNews(),
+    getNews({ company: 'megazone' }),
+    getNews({ company: 'megazonecloud' }),
+    getNews({ company: 'megazonesoft' }),
+  ]);
+
+  const newsByFilter = { all, megazone, megazonecloud, megazonesoft };
 
   return (
     <>
@@ -49,23 +58,15 @@ export default async function NewsPage() {
       <PageLayout
         eyebrow="메가존 소식"
         title="우리 회사 소식 모아보기"
-        description="공식 채널의 새 소식을 매일 아침 모아드려요 — 원문으로 연결됩니다"
+        description="구글 뉴스에서 찾아온 우리 회사 소식이에요"
       >
-        {news.length > 0 ? (
-          <div className="flex flex-col gap-3">
-            {news.map((item) => (
-              <NewsCard key={item.url} news={item} />
-            ))}
-            <p className={newsFootnoteClass}>
-              제목과 요약만 제공하며 본문은 출처(원문)에서 확인할 수 있어요
-            </p>
-          </div>
+        {all.length > 0 ? (
+          <NewsFilter newsByFilter={newsByFilter} />
         ) : (
           <div className={emptyNewsClass}>
-            <p className={emptyNewsSoonClass}>SOON</p>
-            <p className={emptyNewsDescClass}>
-              곧 메가존의 새 소식을 모아서 보여드릴게요
-            </p>
+            <Newspaper className={emptyNewsIconClass} strokeWidth={1.5} />
+            <p className={emptyNewsTitleClass}>소식을 준비 중이에요</p>
+            <p className={emptyNewsDescClass}>조금만 기다려주세요</p>
           </div>
         )}
       </PageLayout>

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 
 import { Newspaper } from 'lucide-react';
 
-import getNews from '@/api/getNews';
+import getNews, { getLastCrawledAt } from '@/api/getNews';
 import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
 import NewsFilter from '@/components/news/NewsFilter';
 import { SITE_NAME } from '@/constants/site';
@@ -32,12 +32,14 @@ export const metadata: Metadata = {
 export const revalidate = 21600;
 
 export default async function NewsPage() {
-  const [all, megazone, megazonecloud, megazonesoft] = await Promise.all([
-    getNews(),
-    getNews({ company: 'megazone' }),
-    getNews({ company: 'megazonecloud' }),
-    getNews({ company: 'megazonesoft' }),
-  ]);
+  const [all, megazone, megazonecloud, megazonesoft, lastCrawledAt] =
+    await Promise.all([
+      getNews(),
+      getNews({ company: 'megazone' }),
+      getNews({ company: 'megazonecloud' }),
+      getNews({ company: 'megazonesoft' }),
+      getLastCrawledAt(),
+    ]);
 
   const newsByFilter = { all, megazone, megazonecloud, megazonesoft };
 
@@ -61,7 +63,10 @@ export default async function NewsPage() {
         description="구글 뉴스에서 찾아온 우리 회사 소식이에요"
       >
         {all.length > 0 ? (
-          <NewsFilter newsByFilter={newsByFilter} />
+          <NewsFilter
+            newsByFilter={newsByFilter}
+            lastCrawledAt={lastCrawledAt}
+          />
         ) : (
           <div className={emptyNewsClass}>
             <Newspaper className={emptyNewsIconClass} strokeWidth={1.5} />

--- a/src/components/news/NewsCard/NewsCard.styles.ts
+++ b/src/components/news/NewsCard/NewsCard.styles.ts
@@ -1,10 +1,10 @@
 export const cardClass =
-  'group bg-surface flex items-start gap-4 px-5 py-4 shadow-[var(--shadow-card)] transition-shadow hover:shadow-[var(--shadow-card-hover)] visited:opacity-70 max-sm:flex-col max-sm:gap-2';
+  'group bg-surface relative flex items-start gap-4 px-5 py-4 shadow-[var(--shadow-card)] transition-shadow hover:shadow-[var(--shadow-card-hover)] visited:opacity-70 max-sm:flex-col max-sm:gap-2';
 
 export const titleClass =
-  'text-ink truncate text-[15.5px] leading-snug font-extrabold tracking-[-0.01em]';
+  'text-ink truncate text-[15.5px] leading-snug font-extrabold tracking-[-0.01em] max-sm:whitespace-normal max-sm:line-clamp-2';
 
 export const dateClass = 'text-muted text-xs';
 
 export const linkLabelClass =
-  'text-muted group-hover:text-accent-deep mt-1 shrink-0 transition-colors';
+  'text-muted group-hover:text-accent-deep mt-1 shrink-0 transition-colors max-sm:absolute max-sm:right-4 max-sm:top-4 max-sm:mt-0';

--- a/src/components/news/NewsCard/NewsCard.styles.ts
+++ b/src/components/news/NewsCard/NewsCard.styles.ts
@@ -1,15 +1,10 @@
 export const cardClass =
-  'group bg-surface flex items-start gap-4 px-5 py-4 shadow-[var(--shadow-card)] transition-shadow hover:shadow-[var(--shadow-card-hover)] max-[560px]:flex-col max-[560px]:gap-2';
-
-export const sourceChipClass =
-  'bg-accent-soft text-accent-text mt-0.5 shrink-0 px-2.5 py-1 text-[11.5px] font-extrabold';
+  'group bg-surface flex items-start gap-4 px-5 py-4 shadow-[var(--shadow-card)] transition-shadow hover:shadow-[var(--shadow-card-hover)] visited:opacity-70 max-sm:flex-col max-sm:gap-2';
 
 export const titleClass =
-  'text-ink text-[15.5px] leading-snug font-extrabold tracking-[-0.01em]';
+  'text-ink truncate text-[15.5px] leading-snug font-extrabold tracking-[-0.01em]';
 
-export const summaryClass = 'text-muted mt-1 text-[13px] leading-relaxed';
-
-export const dateClass = 'text-muted mt-1.5 text-xs';
+export const dateClass = 'text-muted text-xs';
 
 export const linkLabelClass =
-  'text-accent-deep group-hover:text-accent-text mt-0.5 shrink-0 text-[13px] font-bold whitespace-nowrap max-[560px]:mt-0';
+  'text-muted group-hover:text-accent-deep mt-1 shrink-0 transition-colors';

--- a/src/components/news/NewsCard/NewsCard.tsx
+++ b/src/components/news/NewsCard/NewsCard.tsx
@@ -19,7 +19,7 @@ const NewsCard = ({ news }: NewsCardProps) => (
     title="원문으로 이동"
     className={cardClass}
   >
-    <div className="min-w-0 flex-1">
+    <div className="min-w-0 flex-1 max-sm:pr-6">
       <div className="mb-1 flex items-center gap-2">
         {news.source && <span className={dateClass}>{news.source}</span>}
         <span className={dateClass}>

--- a/src/components/news/NewsCard/NewsCard.tsx
+++ b/src/components/news/NewsCard/NewsCard.tsx
@@ -1,11 +1,11 @@
+import { ExternalLink } from 'lucide-react';
+
 import dayjs from '@/lib/dayjs';
 
 import {
   cardClass,
   dateClass,
   linkLabelClass,
-  sourceChipClass,
-  summaryClass,
   titleClass,
 } from './NewsCard.styles';
 import type { NewsCardProps } from './NewsCard.types';
@@ -15,21 +15,26 @@ const NewsCard = ({ news }: NewsCardProps) => (
     href={news.url}
     target="_blank"
     rel="noopener noreferrer"
+    aria-label={`${news.title} (새 탭에서 열립니다)`}
+    title="원문으로 이동"
     className={cardClass}
   >
-    {news.source && <span className={sourceChipClass}>{news.source}</span>}
-
     <div className="min-w-0 flex-1">
-      <h3 className={titleClass}>{news.title}</h3>
-      {news.summary && <p className={summaryClass}>{news.summary}</p>}
-      <div className={dateClass}>
-        {dayjs(news.publishedAt).tz().format('YYYY.M.D')}
+      <div className="mb-1 flex items-center gap-2">
+        {news.source && <span className={dateClass}>{news.source}</span>}
+        <span className={dateClass}>
+          {dayjs(news.publishedAt).tz().format('YYYY.M.D')}
+        </span>
       </div>
+      <h3 className={titleClass}>{news.title}</h3>
     </div>
 
-    <span className={linkLabelClass}>
-      원문 보기 <span aria-hidden="true">↗</span>
-    </span>
+    <ExternalLink
+      size={14}
+      strokeWidth={2.5}
+      className={linkLabelClass}
+      aria-hidden="true"
+    />
   </a>
 );
 

--- a/src/components/news/NewsFilter/NewsFilter.constants.ts
+++ b/src/components/news/NewsFilter/NewsFilter.constants.ts
@@ -1,0 +1,10 @@
+import { COMPANY_LABEL } from '@/models/news';
+
+import type { NewsFilterId } from './NewsFilter.types';
+
+export const FILTER_OPTIONS: { id: NewsFilterId; label: string }[] = [
+  { id: 'all', label: '전체' },
+  { id: 'megazone', label: COMPANY_LABEL.megazone },
+  { id: 'megazonecloud', label: COMPANY_LABEL.megazonecloud },
+  { id: 'megazonesoft', label: COMPANY_LABEL.megazonesoft },
+];

--- a/src/components/news/NewsFilter/NewsFilter.styles.ts
+++ b/src/components/news/NewsFilter/NewsFilter.styles.ts
@@ -1,6 +1,11 @@
 import { cn } from '@/utils/cn';
 
-export const filterBarClass = 'mb-6 flex gap-1';
+export const filterBarClass = 'mb-6 flex items-center gap-1';
+
+export const crawledAtIconClass = 'text-muted cursor-default';
+
+export const crawledAtTooltipClass =
+  'absolute right-0 top-full z-10 mt-1.5 whitespace-nowrap bg-board px-2.5 py-1.5 text-[11px] text-cream opacity-0 pointer-events-none transition-opacity group-hover:opacity-100';
 
 export const filterButtonClass = (active: boolean) =>
   cn(
@@ -19,7 +24,4 @@ export const emptyClass =
 export const emptyTitleClass = 'text-ink-2 text-[15px] font-extrabold';
 
 export const loadMoreClass =
-  'text-muted hover:text-ink-2 mx-auto mt-4 block px-6 py-2.5 text-[13px] font-bold transition-colors';
-
-export const newDotClass =
-  'bg-accent ml-2 inline-block size-1.5 rounded-full align-middle';
+  'text-muted hover:text-ink-2 mx-auto mt-4 flex items-center gap-1.5 px-6 py-2.5 text-[13px] font-bold transition-colors';

--- a/src/components/news/NewsFilter/NewsFilter.styles.ts
+++ b/src/components/news/NewsFilter/NewsFilter.styles.ts
@@ -1,0 +1,25 @@
+import { cn } from '@/utils/cn';
+
+export const filterBarClass = 'mb-6 flex gap-1';
+
+export const filterButtonClass = (active: boolean) =>
+  cn(
+    'px-3 py-1.5 text-[13px] font-bold transition-colors',
+    active ? 'bg-board text-cream' : 'text-muted hover:text-ink-2'
+  );
+
+export const newsGroupClass = 'flex flex-col gap-3';
+
+export const dateHeaderClass =
+  'text-muted text-[11.5px] font-extrabold tracking-[0.08em]';
+
+export const emptyClass =
+  'flex flex-col items-center gap-3 px-1 py-16 text-center';
+
+export const emptyTitleClass = 'text-ink-2 text-[15px] font-extrabold';
+
+export const loadMoreClass =
+  'text-muted hover:text-ink-2 mx-auto mt-4 block px-6 py-2.5 text-[13px] font-bold transition-colors';
+
+export const newDotClass =
+  'bg-accent ml-2 inline-block size-1.5 rounded-full align-middle';

--- a/src/components/news/NewsFilter/NewsFilter.tsx
+++ b/src/components/news/NewsFilter/NewsFilter.tsx
@@ -2,19 +2,22 @@
 
 import { useState } from 'react';
 
+import { ChevronDown, Clock, Loader2 } from 'lucide-react';
+
 import type { CompanyNews } from '@/models/news';
 import dayjs from '@/lib/dayjs';
 
 import NewsCard from '../NewsCard';
 import { FILTER_OPTIONS } from './NewsFilter.constants';
 import {
+  crawledAtIconClass,
+  crawledAtTooltipClass,
   dateHeaderClass,
   emptyClass,
   emptyTitleClass,
   filterBarClass,
   filterButtonClass,
   loadMoreClass,
-  newDotClass,
   newsGroupClass,
 } from './NewsFilter.styles';
 import type { NewsFilterId, NewsFilterProps } from './NewsFilter.types';
@@ -27,7 +30,7 @@ type FilterState = {
   loading: boolean;
 };
 
-const NewsFilter = ({ newsByFilter }: NewsFilterProps) => {
+const NewsFilter = ({ newsByFilter, lastCrawledAt }: NewsFilterProps) => {
   const [active, setActive] = useState<NewsFilterId>('all');
   const [states, setStates] = useState<Record<NewsFilterId, FilterState>>(
     () => {
@@ -80,6 +83,8 @@ const NewsFilter = ({ newsByFilter }: NewsFilterProps) => {
   };
 
   const today = dayjs().tz().format('YYYY-MM-DD');
+  const yesterday = dayjs().tz().subtract(1, 'day').format('YYYY-MM-DD');
+  const twoDaysAgo = dayjs().tz().subtract(2, 'day').format('YYYY-MM-DD');
 
   const grouped = items.reduce<Record<string, typeof items>>((acc, item) => {
     const key = dayjs(item.publishedAt).tz().format('YYYY-MM-DD');
@@ -104,6 +109,19 @@ const NewsFilter = ({ newsByFilter }: NewsFilterProps) => {
             {label}
           </button>
         ))}
+        {lastCrawledAt && (
+          <div className="group relative ml-auto">
+            <Clock
+              size={12}
+              className={crawledAtIconClass}
+              aria-label={`마지막 업데이트 ${dayjs(lastCrawledAt).tz().format('M월 D일 HH:mm')}`}
+            />
+            <span className={crawledAtTooltipClass}>
+              마지막 업데이트{' '}
+              {dayjs(lastCrawledAt).tz().format('M월 D일 HH:mm')}
+            </span>
+          </div>
+        )}
       </div>
 
       {items.length > 0 ? (
@@ -112,10 +130,13 @@ const NewsFilter = ({ newsByFilter }: NewsFilterProps) => {
             {dateGroups.map(([dateKey, group]) => (
               <div key={dateKey} className={newsGroupClass}>
                 <p className={dateHeaderClass}>
-                  {dayjs(dateKey).tz().format('M월 D일 dddd')}
-                  {dateKey === today && (
-                    <span className={newDotClass} aria-label="오늘" />
-                  )}
+                  {dateKey === today
+                    ? '오늘'
+                    : dateKey === yesterday
+                      ? '어제'
+                      : dateKey === twoDaysAgo
+                        ? '그저께'
+                        : dayjs(dateKey).tz().format('M월 D일 dddd')}
                 </p>
                 {group.map((item) => (
                   <NewsCard key={item.url} news={item} />
@@ -130,6 +151,15 @@ const NewsFilter = ({ newsByFilter }: NewsFilterProps) => {
               disabled={loading}
               className={loadMoreClass}
             >
+              {loading ? (
+                <Loader2
+                  size={14}
+                  className="animate-spin"
+                  aria-hidden="true"
+                />
+              ) : (
+                <ChevronDown size={14} aria-hidden="true" />
+              )}
               {loading ? '불러오는 중…' : '더보기'}
             </button>
           )}

--- a/src/components/news/NewsFilter/NewsFilter.tsx
+++ b/src/components/news/NewsFilter/NewsFilter.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { CompanyNews } from '@/models/news';
+import dayjs from '@/lib/dayjs';
+
+import NewsCard from '../NewsCard';
+import { FILTER_OPTIONS } from './NewsFilter.constants';
+import {
+  dateHeaderClass,
+  emptyClass,
+  emptyTitleClass,
+  filterBarClass,
+  filterButtonClass,
+  loadMoreClass,
+  newDotClass,
+  newsGroupClass,
+} from './NewsFilter.styles';
+import type { NewsFilterId, NewsFilterProps } from './NewsFilter.types';
+
+const PAGE_SIZE = 20;
+
+type FilterState = {
+  items: CompanyNews[];
+  hasMore: boolean;
+  loading: boolean;
+};
+
+const NewsFilter = ({ newsByFilter }: NewsFilterProps) => {
+  const [active, setActive] = useState<NewsFilterId>('all');
+  const [states, setStates] = useState<Record<NewsFilterId, FilterState>>(
+    () => {
+      const init = (id: NewsFilterId): FilterState => ({
+        items: newsByFilter[id],
+        hasMore: newsByFilter[id].length === PAGE_SIZE,
+        loading: false,
+      });
+      return {
+        all: init('all'),
+        megazone: init('megazone'),
+        megazonecloud: init('megazonecloud'),
+        megazonesoft: init('megazonesoft'),
+      };
+    }
+  );
+
+  const { items, hasMore, loading } = states[active];
+
+  const loadMore = async () => {
+    setStates((prev) => ({
+      ...prev,
+      [active]: { ...prev[active], loading: true },
+    }));
+
+    const params = new URLSearchParams({
+      offset: String(items.length),
+      limit: String(PAGE_SIZE),
+    });
+    if (active !== 'all') params.set('company', active);
+
+    const res = await fetch(`/api/news?${params}`);
+    if (!res.ok) {
+      setStates((prev) => ({
+        ...prev,
+        [active]: { ...prev[active], loading: false },
+      }));
+      return;
+    }
+    const next: CompanyNews[] = await res.json();
+
+    setStates((prev) => ({
+      ...prev,
+      [active]: {
+        items: [...prev[active].items, ...next],
+        hasMore: next.length === PAGE_SIZE,
+        loading: false,
+      },
+    }));
+  };
+
+  const today = dayjs().tz().format('YYYY-MM-DD');
+
+  const grouped = items.reduce<Record<string, typeof items>>((acc, item) => {
+    const key = dayjs(item.publishedAt).tz().format('YYYY-MM-DD');
+    (acc[key] ??= []).push(item);
+    return acc;
+  }, {});
+
+  const dateGroups = Object.entries(grouped).sort(([a], [b]) =>
+    b.localeCompare(a)
+  );
+
+  return (
+    <div>
+      <div className={filterBarClass}>
+        {FILTER_OPTIONS.map(({ id, label }) => (
+          <button
+            key={id}
+            onClick={() => setActive(id)}
+            className={filterButtonClass(active === id)}
+            aria-pressed={active === id}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {items.length > 0 ? (
+        <>
+          <div className="flex flex-col gap-8">
+            {dateGroups.map(([dateKey, group]) => (
+              <div key={dateKey} className={newsGroupClass}>
+                <p className={dateHeaderClass}>
+                  {dayjs(dateKey).tz().format('M월 D일 dddd')}
+                  {dateKey === today && (
+                    <span className={newDotClass} aria-label="오늘" />
+                  )}
+                </p>
+                {group.map((item) => (
+                  <NewsCard key={item.url} news={item} />
+                ))}
+              </div>
+            ))}
+          </div>
+
+          {hasMore && (
+            <button
+              onClick={loadMore}
+              disabled={loading}
+              className={loadMoreClass}
+            >
+              {loading ? '불러오는 중…' : '더보기'}
+            </button>
+          )}
+        </>
+      ) : (
+        <div className={emptyClass}>
+          <p className={emptyTitleClass}>해당하는 소식이 없어요</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NewsFilter;

--- a/src/components/news/NewsFilter/NewsFilter.types.ts
+++ b/src/components/news/NewsFilter/NewsFilter.types.ts
@@ -4,4 +4,5 @@ export type NewsFilterId = 'all' | NewsCompany;
 
 export type NewsFilterProps = {
   newsByFilter: Record<NewsFilterId, CompanyNews[]>;
+  lastCrawledAt: string | null;
 };

--- a/src/components/news/NewsFilter/NewsFilter.types.ts
+++ b/src/components/news/NewsFilter/NewsFilter.types.ts
@@ -1,0 +1,7 @@
+import type { CompanyNews, NewsCompany } from '@/models/news';
+
+export type NewsFilterId = 'all' | NewsCompany;
+
+export type NewsFilterProps = {
+  newsByFilter: Record<NewsFilterId, CompanyNews[]>;
+};

--- a/src/components/news/NewsFilter/index.ts
+++ b/src/components/news/NewsFilter/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NewsFilter';

--- a/src/models/news.ts
+++ b/src/models/news.ts
@@ -8,3 +8,9 @@ export type CompanyNews = {
   company: NewsCompany;
   publishedAt: string; // ISO 8601
 };
+
+export const COMPANY_LABEL: Record<NewsCompany, string> = {
+  megazone: '메가존',
+  megazonecloud: '메가존클라우드',
+  megazonesoft: '메가존소프트',
+};


### PR DESCRIPTION
## 개요

> **한줄 요약**: 메가존 소식 페이지에 회사별 필터 탭·더보기 페이지네이션을 추가하고 NewsCard UI를 정비합니다

메가존 3사 뉴스가 섞여 노출되어 원하는 회사 소식만 골라보기 어렵다는 문제를 해결합니다. 출처 칩 제거·레이아웃 정리를 병행해 카드 타이틀 시작점의 가변 문제도 수정했습니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **데이터 레이어** | `getNews.ts` | 옵션 객체로 시그니처 변경, `offset`·`company` 필터 파라미터 추가, `getLastCrawledAt()` 추가 |
| **API 라우트** | `route.ts` (news) | 클라이언트 더보기용 GET `/api/news?company=&offset=&limit=` 신설 |
| **필터 컴포넌트** | `NewsFilter.tsx`, `NewsFilter.styles.ts`, `NewsFilter.constants.ts`, `NewsFilter.types.ts` | 전체·메가존·클라우드·소프트 4탭 필터, 탭별 독립 상태, 더보기(ChevronDown/Loader2 아이콘), 마지막 업데이트 Clock 아이콘 툴팁, 날짜 헤더 오늘·어제·그저께 레이블 |
| **NewsCard UI** | `NewsCard.tsx`, `NewsCard.styles.ts`, `NewsCard.types.ts` | 출처 칩 제거, 언론사·날짜 메타 한 줄 정렬, 아이콘만 링크 표시, 모바일 타이틀 2줄 클램프, 링크 아이콘 우상단 고정 (640px 미만) |
| **페이지** | `page.tsx`, `page.styles.ts` | 5개 병렬 쿼리(필터 4 + 마지막 수집일 1)로 SSR, `NewsFilter`에 위임 |
| **모델** | `models/news.ts` | `COMPANY_LABEL` 상수 추가 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 서버 as 서버(ISR)
    participant DB as Supabase
    participant 클라 as NewsFilter(Client)
    participant API as /api/news

    서버->>DB: getNews() × 4 + getLastCrawledAt() (Promise.all)
    DB-->>서버: 전체·메가존·클라우드·소프트 각 20건 + 마지막 수집 시각
    서버-->>클라: newsByFilter + lastCrawledAt 전달
    클라->>클라: 탭 전환 → newsByFilter[active] 즉시 표시
    클라->>API: 더보기 클릭 → GET /api/news?company=&offset=20
    API->>DB: getNews({ company, offset, limit })
    DB-->>API: 다음 20건
    API-->>클라: JSON 응답 (res.ok 체크 후 append)
```

&nbsp;

## 테스트 계획

- [ ] 전체 탭: 최근 20개 뉴스 혼합 표시 확인
- [ ] 회사별 탭: 해당 회사 뉴스만 필터링 확인
- [ ] 더보기: 21번째 항목부터 append, 로딩 중 버튼 비활성 및 스피너 표시 확인
- [ ] 더보기 API 오류 시 기존 목록 유지·로딩 해제 확인 (res.ok 체크)
- [ ] 뉴스 0건 탭: 빈 상태 메시지 표시 확인
- [ ] 마지막 업데이트 Clock 아이콘 호버 시 툴팁 날짜 표시 확인
- [ ] 날짜 헤더: 오늘·어제·그저께 레이블, 그 이전은 날짜 형식 확인
- [ ] 모바일(640px 미만): 타이틀 2줄 클램프, 링크 아이콘 카드 우상단 배치 확인

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)