### PR TITLE
fix: [모바일 UX] 툴팁·메뉴 활성 강조·레이아웃 일관성 개선

### DIFF
--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 
+import { Gamepad2 } from 'lucide-react';
+
 import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
 import { GameCard } from '@/components/games';
 import { GAMES } from '@/constants/games';
@@ -36,7 +38,12 @@ export default function GamesPage() {
       <SiteHeader />
       <PageLayout
         eyebrow="미니게임"
-        title={`${SITE_NAME} 미니게임`}
+        title={
+          <span className="inline-flex items-center gap-2.5">
+            <Gamepad2 size={26} strokeWidth={2} />
+            <span>{`${SITE_NAME} 미니게임`}</span>
+          </span>
+        }
         description="사내 구성원을 위한 소소한 미니게임 모음"
       >
         <div className="flex flex-col gap-3">

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -59,7 +59,12 @@ export default async function NewsPage() {
       <SiteHeader />
       <PageLayout
         eyebrow="메가존 소식"
-        title="우리 회사 소식 모아보기"
+        title={
+          <span className="inline-flex items-center gap-2.5">
+            <Newspaper size={26} strokeWidth={2} />
+            <span>우리 회사 소식 모아보기</span>
+          </span>
+        }
         description="구글 뉴스에서 찾아온 우리 회사 소식이에요"
       >
         {all.length > 0 ? (

--- a/src/app/notice/page.tsx
+++ b/src/app/notice/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 
+import { Bell } from 'lucide-react';
+
 import { getAnnouncements } from '@/api/getAnnouncements';
 import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
 import { SITE_NAME } from '@/constants/site';
@@ -52,7 +54,12 @@ export default function NoticePage() {
       <SiteHeader />
       <PageLayout
         eyebrow="공지사항"
-        title={`${SITE_NAME} 소식`}
+        title={
+          <span className="inline-flex items-center gap-2.5">
+            <Bell size={26} strokeWidth={2} />
+            <span>{`${SITE_NAME} 소식`}</span>
+          </span>
+        }
         description="새 기능, 점검, 운영 안내를 여기서 알려드려요"
       >
         {notices.length > 0 ? (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,7 +49,7 @@ export default async function Home() {
       />
       <SiteHeader />
       <PageLayout
-        eyebrow="식단표"
+        eyebrow="메가존 구내식당"
         title={<HeroStatus menus={menus} />}
         description="매주 목요일 업데이트되는 구내식당 코스별 식단표에요"
       >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,7 +49,7 @@ export default async function Home() {
       />
       <SiteHeader />
       <PageLayout
-        eyebrow="메가존 구내식당"
+        eyebrow="식단표"
         title={<HeroStatus menus={menus} />}
         description="매주 목요일 업데이트되는 구내식당 코스별 식단표에요"
       >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import {
   SiteFooter,
   SiteHeader,
 } from '@/components/@shared';
-import { HeroDate, HeroStatus } from '@/components/home';
+import { HeroStatus } from '@/components/home';
 import { MenuBoard } from '@/components/menu';
 import dayjs from '@/lib/dayjs';
 import { formatYYYYMMDD, getWeekDays } from '@/utils/date';
@@ -48,7 +48,11 @@ export default async function Home() {
         }}
       />
       <SiteHeader />
-      <PageLayout eyebrow={<HeroDate />} title={<HeroStatus menus={menus} />}>
+      <PageLayout
+        eyebrow="식단표"
+        title={<HeroStatus menus={menus} />}
+        description="매일 업데이트되는 구내식당 코스별 식단표에요"
+      >
         <ErrorBoundary>
           <MenuBoard menus={menus} />
         </ErrorBoundary>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,7 +51,7 @@ export default async function Home() {
       <PageLayout
         eyebrow="식단표"
         title={<HeroStatus menus={menus} />}
-        description="매일 업데이트되는 구내식당 코스별 식단표에요"
+        description="매주 목요일 업데이트되는 구내식당 코스별 식단표에요"
       >
         <ErrorBoundary>
           <MenuBoard menus={menus} />

--- a/src/components/@shared/layout/SiteFooter/SiteFooter.tsx
+++ b/src/components/@shared/layout/SiteFooter/SiteFooter.tsx
@@ -10,7 +10,7 @@ import {
 } from './SiteFooter.styles';
 
 const SiteFooter = () => (
-  <footer className="mt-16">
+  <footer className="mt-8">
     <div className="mx-auto w-[min(880px,calc(100%-40px))] py-6">
       <div className="flex flex-col items-center gap-4 text-center min-[560px]:flex-row min-[560px]:items-center min-[560px]:justify-between min-[560px]:gap-0 min-[560px]:text-left">
         {/* 브랜드 단 */}

--- a/src/components/@shared/layout/SiteFooter/SiteFooter.tsx
+++ b/src/components/@shared/layout/SiteFooter/SiteFooter.tsx
@@ -12,19 +12,23 @@ import {
 const SiteFooter = () => (
   <footer className="mt-16">
     <div className="mx-auto w-[min(880px,calc(100%-40px))] py-6">
-      <div className="flex flex-col gap-3 min-[560px]:flex-row min-[560px]:items-center min-[560px]:justify-between">
-        <div className="flex items-center gap-5">
+      <div className="flex flex-col items-center gap-4 text-center min-[560px]:flex-row min-[560px]:items-center min-[560px]:justify-between min-[560px]:gap-0 min-[560px]:text-left">
+        {/* 브랜드 단 */}
+        <div className="flex flex-col items-center gap-1 min-[560px]:flex-row min-[560px]:gap-5">
           <span className={footerBrandNameClass}>{SITE_NAME}</span>
           <p className={footerDescClass}>
             메가존 직원을 위한 구내식당 메뉴 서비스
           </p>
         </div>
-        <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
-          {FOOTER_LINKS.map((l) => (
-            <Link key={l.label} href={l.href} className={footerLinkClass}>
-              {l.label}
-            </Link>
-          ))}
+        {/* 링크 단 + 저작권 단 */}
+        <div className="flex flex-col items-center gap-2 min-[560px]:flex-row min-[560px]:flex-wrap min-[560px]:items-center min-[560px]:gap-x-5 min-[560px]:gap-y-2">
+          <div className="flex flex-wrap justify-center gap-x-5 gap-y-2 min-[560px]:contents">
+            {FOOTER_LINKS.map((l) => (
+              <Link key={l.label} href={l.href} className={footerLinkClass}>
+                {l.label}
+              </Link>
+            ))}
+          </div>
           <span className={footerCopyrightClass}>© 2026 {SITE_NAME}</span>
         </div>
       </div>

--- a/src/components/@shared/layout/SiteHeader/SiteHeader.styles.ts
+++ b/src/components/@shared/layout/SiteHeader/SiteHeader.styles.ts
@@ -45,5 +45,5 @@ export const mobileOverlayClass = (menuOpen: boolean) =>
 export const mobileNavLinkClass = (active: boolean) =>
   cn(
     'flex items-center justify-between border-b border-line/50 py-3.5 text-[15px] font-semibold',
-    active ? 'text-ink' : 'text-ink-2'
+    active ? 'text-accent-text' : 'text-ink-2'
   );

--- a/src/components/@shared/layout/SiteHeader/SiteHeader.tsx
+++ b/src/components/@shared/layout/SiteHeader/SiteHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Bell, Menu, X } from 'lucide-react';
+import { Bell, Check, Menu, X } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
@@ -134,6 +134,7 @@ const SiteHeader = () => {
                 className={mobileNavLinkClass(active)}
               >
                 {item.label}
+                {active && <Check size={16} strokeWidth={2.5} aria-hidden />}
               </Link>
             );
           })}

--- a/src/components/menu/MenuBoard/MenuBoard.tsx
+++ b/src/components/menu/MenuBoard/MenuBoard.tsx
@@ -81,7 +81,7 @@ const MenuBoard = ({ menus }: MenuBoardProps) => {
     <section className={sectionClass}>
       <div className="flex items-center justify-between px-6 py-4">
         <div className="flex items-center gap-2">
-          <h2 className={menuHeadingTitleClass}>식단표</h2>
+          <h2 className={menuHeadingTitleClass}>메가존 구내식당</h2>
           <p className={menuSubheadingClass}>
             <Clock
               size={9}

--- a/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.styles.ts
@@ -1,8 +1,16 @@
 import { VoteType } from '@/models/vote';
 import { cn } from '@/utils/cn';
 
-export const TOOLTIP =
-  "pointer-events-none invisible absolute top-full left-1/2 z-10 mt-2 -translate-x-1/2 whitespace-nowrap bg-ink px-2 py-1 text-[10px] font-medium text-cream opacity-0 transition-opacity pointer-events-none group-hover:visible group-hover:opacity-100 before:absolute before:bottom-full before:left-1/2 before:-translate-x-1/2 before:border-4 before:border-transparent before:border-b-ink before:content-['']";
+const TOOLTIP_BASE =
+  'pointer-events-none absolute top-full left-1/2 z-10 mt-2 -translate-x-1/2 whitespace-nowrap bg-ink px-2 py-1 text-[10px] font-medium text-cream transition-opacity before:absolute before:bottom-full before:left-1/2 before:-translate-x-1/2 before:border-4 before:border-transparent before:border-b-ink before:content-[""]';
+
+export const tooltipClass = (isOpen: boolean) =>
+  cn(
+    TOOLTIP_BASE,
+    isOpen
+      ? 'visible opacity-100'
+      : 'invisible opacity-0 group-hover:visible group-hover:opacity-100'
+  );
 
 export const courseRowClass = 'px-5 py-6';
 

--- a/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { ThumbsDown, ThumbsUp, Users } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { MenuCategoryLabel } from '@/constants/menu';
 
 import {
-  TOOLTIP,
+  tooltipClass,
   courseRowClass,
   courseRowHeaderClass,
   courseLabelClass,
@@ -27,9 +27,35 @@ import { MenuBoardCourseRowProps } from './MenuBoardCourseRow.types';
 
 const MenuBoardCourseRow = ({ menu, vote, pick }: MenuBoardCourseRowProps) => {
   const [animating, setAnimating] = useState<'up' | 'down' | null>(null);
+  const [longPressTarget, setLongPressTarget] = useState<'up' | 'down' | null>(
+    null
+  );
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressActivated = useRef(false);
 
   const total = menu.items.reduce((sum, item) => sum + (item.kcal ?? 0), 0);
   const myVote = vote?.result?.myVote ?? null;
+
+  const startLongPress = (type: 'up' | 'down') => {
+    longPressActivated.current = false;
+    longPressTimer.current = setTimeout(() => {
+      setLongPressTarget(type);
+      longPressActivated.current = true;
+    }, 500);
+  };
+
+  const cancelLongPress = () => {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  };
+
+  useEffect(() => {
+    const dismiss = () => setLongPressTarget(null);
+    document.addEventListener('touchstart', dismiss);
+    return () => document.removeEventListener('touchstart', dismiss);
+  }, []);
 
   const handleVote = (type: 'up' | 'down') => {
     if (!vote?.onVote || vote?.isSubmitting) return;
@@ -72,7 +98,19 @@ const MenuBoardCourseRow = ({ menu, vote, pick }: MenuBoardCourseRowProps) => {
           <div className={voteGroupClass}>
             <button
               type="button"
-              onClick={() => handleVote('up')}
+              onClick={() => {
+                if (longPressActivated.current) {
+                  longPressActivated.current = false;
+                  return;
+                }
+                handleVote('up');
+              }}
+              onTouchStart={(e) => {
+                e.stopPropagation();
+                startLongPress('up');
+              }}
+              onTouchEnd={cancelLongPress}
+              onTouchMove={cancelLongPress}
               disabled={vote.isSubmitting}
               aria-pressed={myVote === 'up'}
               aria-label="맛있어요"
@@ -84,11 +122,25 @@ const MenuBoardCourseRow = ({ menu, vote, pick }: MenuBoardCourseRowProps) => {
               <span className={tabularNumsClass}>
                 {vote.result?.up_count ?? 0}
               </span>
-              <span className={TOOLTIP}>맛있었어요</span>
+              <span className={tooltipClass(longPressTarget === 'up')}>
+                맛있었어요
+              </span>
             </button>
             <button
               type="button"
-              onClick={() => handleVote('down')}
+              onClick={() => {
+                if (longPressActivated.current) {
+                  longPressActivated.current = false;
+                  return;
+                }
+                handleVote('down');
+              }}
+              onTouchStart={(e) => {
+                e.stopPropagation();
+                startLongPress('down');
+              }}
+              onTouchEnd={cancelLongPress}
+              onTouchMove={cancelLongPress}
               disabled={vote.isSubmitting}
               aria-pressed={myVote === 'down'}
               aria-label="별로예요"
@@ -100,7 +152,9 @@ const MenuBoardCourseRow = ({ menu, vote, pick }: MenuBoardCourseRowProps) => {
               <span className={tabularNumsClass}>
                 {vote.result?.down_count ?? 0}
               </span>
-              <span className={TOOLTIP}>별로였어요</span>
+              <span className={tooltipClass(longPressTarget === 'down')}>
+                별로였어요
+              </span>
             </button>
           </div>
         )}

--- a/src/components/news/NewsFilter/NewsFilter.styles.ts
+++ b/src/components/news/NewsFilter/NewsFilter.styles.ts
@@ -2,10 +2,13 @@ import { cn } from '@/utils/cn';
 
 export const filterBarClass = 'mb-6 flex items-center gap-1';
 
-export const crawledAtIconClass = 'text-muted cursor-default';
+export const crawledAtIconClass = 'text-muted';
 
-export const crawledAtTooltipClass =
-  'absolute right-0 top-full z-10 mt-1.5 whitespace-nowrap bg-board px-2.5 py-1.5 text-[11px] text-cream opacity-0 pointer-events-none transition-opacity group-hover:opacity-100';
+export const crawledAtTooltipClass = (isOpen: boolean) =>
+  cn(
+    'absolute right-0 top-full z-10 mt-1.5 whitespace-nowrap bg-board px-2.5 py-1.5 text-[11px] text-cream pointer-events-none transition-opacity group-hover:opacity-100',
+    isOpen ? 'opacity-100' : 'opacity-0'
+  );
 
 export const filterButtonClass = (active: boolean) =>
   cn(

--- a/src/components/news/NewsFilter/NewsFilter.styles.ts
+++ b/src/components/news/NewsFilter/NewsFilter.styles.ts
@@ -6,8 +6,10 @@ export const crawledAtIconClass = 'text-muted';
 
 export const crawledAtTooltipClass = (isOpen: boolean) =>
   cn(
-    'absolute right-0 top-full z-10 mt-1.5 whitespace-nowrap bg-board px-2.5 py-1.5 text-[11px] text-cream pointer-events-none transition-opacity group-hover:opacity-100',
-    isOpen ? 'opacity-100' : 'opacity-0'
+    'absolute right-0 top-full z-10 mt-1.5 whitespace-nowrap bg-board px-2.5 py-1.5 text-[11px] text-cream pointer-events-none transition-opacity',
+    isOpen
+      ? 'visible opacity-100'
+      : 'invisible opacity-0 group-hover:visible group-hover:opacity-100'
   );
 
 export const filterButtonClass = (active: boolean) =>

--- a/src/components/news/NewsFilter/NewsFilter.tsx
+++ b/src/components/news/NewsFilter/NewsFilter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { ChevronDown, Clock, Loader2 } from 'lucide-react';
 
@@ -33,6 +33,14 @@ type FilterState = {
 const NewsFilter = ({ newsByFilter, lastCrawledAt }: NewsFilterProps) => {
   const [active, setActive] = useState<NewsFilterId>('all');
   const [crawledAtOpen, setCrawledAtOpen] = useState(false);
+
+  useEffect(() => {
+    if (!crawledAtOpen) return;
+    const close = () => setCrawledAtOpen(false);
+    document.addEventListener('click', close);
+    return () => document.removeEventListener('click', close);
+  }, [crawledAtOpen]);
+
   const [states, setStates] = useState<Record<NewsFilterId, FilterState>>(
     () => {
       const init = (id: NewsFilterId): FilterState => ({
@@ -119,7 +127,6 @@ const NewsFilter = ({ newsByFilter, lastCrawledAt }: NewsFilterProps) => {
               e.stopPropagation();
               setCrawledAtOpen((v) => !v);
             }}
-            onBlur={() => setCrawledAtOpen(false)}
           >
             <Clock size={12} className={crawledAtIconClass} aria-hidden />
             <span className={crawledAtTooltipClass(crawledAtOpen)}>

--- a/src/components/news/NewsFilter/NewsFilter.tsx
+++ b/src/components/news/NewsFilter/NewsFilter.tsx
@@ -32,6 +32,7 @@ type FilterState = {
 
 const NewsFilter = ({ newsByFilter, lastCrawledAt }: NewsFilterProps) => {
   const [active, setActive] = useState<NewsFilterId>('all');
+  const [crawledAtOpen, setCrawledAtOpen] = useState(false);
   const [states, setStates] = useState<Record<NewsFilterId, FilterState>>(
     () => {
       const init = (id: NewsFilterId): FilterState => ({
@@ -110,17 +111,22 @@ const NewsFilter = ({ newsByFilter, lastCrawledAt }: NewsFilterProps) => {
           </button>
         ))}
         {lastCrawledAt && (
-          <div className="group relative ml-auto">
-            <Clock
-              size={12}
-              className={crawledAtIconClass}
-              aria-label={`마지막 업데이트 ${dayjs(lastCrawledAt).tz().format('M월 D일 HH:mm')}`}
-            />
-            <span className={crawledAtTooltipClass}>
+          <button
+            type="button"
+            className="group relative ml-auto"
+            aria-label={`마지막 업데이트 ${dayjs(lastCrawledAt).tz().format('M월 D일 HH:mm')}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              setCrawledAtOpen((v) => !v);
+            }}
+            onBlur={() => setCrawledAtOpen(false)}
+          >
+            <Clock size={12} className={crawledAtIconClass} aria-hidden />
+            <span className={crawledAtTooltipClass(crawledAtOpen)}>
               마지막 업데이트{' '}
               {dayjs(lastCrawledAt).tz().format('M월 D일 HH:mm')}
             </span>
-          </div>
+          </button>
         )}
       </div>
 

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -5,8 +5,8 @@ export const SITE_NAME = 'MegaBobs';
 export const NAV_ITEMS: NavItem[] = [
   { label: '식단표', href: '/' },
   { label: '공지사항', href: '/notice' },
-  { label: '미니게임', href: '/games' },
   { label: '메가존 소식', href: '/news' },
+  { label: '미니게임', href: '/games' },
 ];
 
 export const FOOTER_LINKS: { label: string; href: string }[] = [


### PR DESCRIPTION
## 개요

> **한줄 요약**: 모바일 웹 UX 버그 수정 및 전 페이지 레이아웃 일관성 확보

모바일에서 hover 이벤트 미지원으로 인해 툴팁이 동작하지 않고, 햄버거 메뉴에서 현재 페이지 강조가 없어 위치 파악이 어려웠습니다. 또한 식단표 홈이 다른 페이지와 다른 헤더 구조를 사용해 이질감이 있었습니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **네비게이션** | `site.ts` | 순서 재정렬 — 정보성 콘텐츠 그룹화 |
| **식단표 레이아웃** | `page.tsx`, `MenuBoard.tsx` | eyebrow·description 추가, 카드 헤딩 변경 |
| **모바일 메뉴** | `SiteHeader.tsx`, `SiteHeader.styles.ts` | 활성 항목 accent-text + Check 아이콘 |
| **투표 툴팁** | `MenuBoardCourseRow.tsx`, `.styles.ts` | 롱터치(500ms) 지원, 외부 터치 닫기 |
| **소식 툴팁** | `NewsFilter.tsx`, `NewsFilter.styles.ts` | 탭 토글 + document click 닫기 + invisible 추가 |
| **공통 레이아웃** | `notice/page.tsx`, `games/page.tsx`, `news/page.tsx`, `SiteFooter.tsx` | 페이지 타이틀 아이콘, 모바일 footer 3단 중앙정렬 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 유저
    participant 투표버튼
    participant 툴팁
    participant 문서

    유저->>투표버튼: 롱터치 시작 (touchstart)
    투표버튼->>투표버튼: 500ms 타이머 시작
    Note over 유저,투표버튼: 500ms 경과
    투표버튼->>툴팁: 표시 (longPressTarget 설정)
    투표버튼->>투표버튼: click 이벤트 차단 (투표 방지)
    유저->>문서: 외부 터치 (touchstart)
    문서->>툴팁: 닫기 (setLongPressTarget null)
```

&nbsp;

## 테스트 계획

- [ ] 모바일 — 투표 버튼 롱터치(0.5초) 시 툴팁 표시, 짧은 탭은 투표 동작
- [ ] 모바일 — 툴팁 표시 후 외부 터치 시 닫힘 확인
- [ ] 모바일 — 소식 Clock 아이콘 탭 시 툴팁 토글, 외부 탭 시 닫힘
- [ ] 모바일 — 햄버거 메뉴 현재 페이지 accent-text + Check 아이콘 표시
- [ ] 모바일 — Footer 3단 중앙정렬 (브랜드/링크/저작권)
- [ ] 데스크톱 — 투표 버튼 hover 툴팁 정상 동작
- [ ] 데스크톱 — Footer 기존 좌우 배치 유지
- [ ] 전 페이지 — 네비게이션 순서 [식단표·공지사항·메가존소식·미니게임] 확인

---

> 🎭 **오늘의 커밋 시**
>
> 👆 호버는 손이 없어 슬프지만
> 🤙 롱터치 500ms면 툴팁이 떠오르지
> ✅ 체크마크 하나로 내 자리를 알고
> 📰 소식 시계 탭하면 업데이트 시각
> 🦶 푸터는 가지런히 세 줄로 정렬

🤖 Generated with [Claude Code](https://claude.com/claude-code)