### PR TITLE
feat: [DayBar UX] 날짜 내비게이션 개선 및 휴무일 빈 상태 문구 추가

### DIFF
--- a/src/components/@shared/layout/SiteHeader/SiteHeader.styles.ts
+++ b/src/components/@shared/layout/SiteHeader/SiteHeader.styles.ts
@@ -18,6 +18,12 @@ export const desktopNavLinkClass = (active: boolean) =>
     active ? 'text-ink' : 'text-muted hover:text-ink-2'
   );
 
+export const desktopComingSoonClass =
+  'flex cursor-default select-none items-center gap-1.5 px-3 py-2 text-[13.5px] font-semibold text-muted/40';
+
+export const comingSoonBadgeClass =
+  'bg-surface-warm px-1 py-0.5 text-[9px] font-bold leading-none tracking-wider text-muted';
+
 export const desktopBellLinkClass =
   'text-ink-2 relative flex size-9 items-center justify-center max-[640px]:hidden';
 
@@ -47,3 +53,6 @@ export const mobileNavLinkClass = (active: boolean) =>
     'flex items-center justify-between border-b border-line/50 py-3.5 text-[15px] font-semibold',
     active ? 'text-accent-text' : 'text-ink-2'
   );
+
+export const mobileComingSoonClass =
+  'flex cursor-default select-none items-center justify-between border-b border-line/50 py-3.5 text-[15px] font-semibold text-muted/40';

--- a/src/components/@shared/layout/SiteHeader/SiteHeader.tsx
+++ b/src/components/@shared/layout/SiteHeader/SiteHeader.tsx
@@ -13,11 +13,14 @@ import { hasNewAnnouncement } from '@/utils/announcementPolicy';
 import {
   bellDotClass,
   bellSpanClass,
+  comingSoonBadgeClass,
   desktopBellLinkClass,
+  desktopComingSoonClass,
   desktopNavClass,
   desktopNavLinkClass,
   headerClass,
   logoLinkClass,
+  mobileComingSoonClass,
   mobileBellLinkClass,
   mobileMenuButtonClass,
   mobileNavLinkClass,
@@ -62,6 +65,14 @@ const SiteHeader = () => {
 
           <nav className={desktopNavClass}>
             {NAV_ITEMS.map((item) => {
+              if (item.comingSoon) {
+                return (
+                  <span key={item.href} className={desktopComingSoonClass}>
+                    {item.label}
+                    <span className={comingSoonBadgeClass}>준비중</span>
+                  </span>
+                );
+              }
               const active = pathname === item.href;
               return (
                 <Link
@@ -124,6 +135,14 @@ const SiteHeader = () => {
       <div className={mobileOverlayClass(menuOpen)}>
         <nav className="mx-auto flex w-[min(880px,calc(100%-40px))] flex-col pt-1 pb-4">
           {NAV_ITEMS.map((item) => {
+            if (item.comingSoon) {
+              return (
+                <span key={item.href} className={mobileComingSoonClass}>
+                  {item.label}
+                  <span className={comingSoonBadgeClass}>준비중</span>
+                </span>
+              );
+            }
             const active = pathname === item.href;
             return (
               <Link

--- a/src/components/menu/MenuBoard/MenuBoard.styles.ts
+++ b/src/components/menu/MenuBoard/MenuBoard.styles.ts
@@ -1,5 +1,3 @@
-import { cn } from '@/utils/cn';
-
 export const sectionClass =
   'bg-surface flex flex-col shadow-[var(--shadow-card)]';
 
@@ -8,11 +6,5 @@ export const menuHeadingTitleClass =
 
 export const menuSubheadingClass =
   'text-ink-2 flex items-center gap-1 text-[11px] font-medium';
-
-export const todayButtonClass = (isActive: boolean) =>
-  cn(
-    'flex items-center gap-1.5 border border-accent/50 bg-accent-soft px-3 py-1 text-[11px] font-bold text-accent-text transition-opacity hover:opacity-70',
-    isActive ? 'invisible' : 'visible'
-  );
 
 export const menuBodyClass = 'flex flex-col min-h-[180px] overflow-hidden';

--- a/src/components/menu/MenuBoard/MenuBoard.tsx
+++ b/src/components/menu/MenuBoard/MenuBoard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CalendarDays, Clock } from 'lucide-react';
+import { Clock } from 'lucide-react';
 import { useLayoutEffect, useMemo, useRef } from 'react';
 
 import { CAFETERIA_LABEL } from '@/constants/cafeteria';
@@ -21,12 +21,11 @@ import {
   menuHeadingTitleClass,
   menuSubheadingClass,
   sectionClass,
-  todayButtonClass,
 } from './MenuBoard.styles';
 import { MenuBoardProps } from './MenuBoard.types';
 
 const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
-  const { today, selectedDate, goToToday } = useDateStore();
+  const { today, selectedDate } = useDateStore();
   const mounted = useHasMounted();
   const dateStr = formatYYYYMMDD(selectedDate);
   const hasMenus = useMemo(
@@ -80,28 +79,17 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
 
   return (
     <section className={sectionClass}>
-      <div className="flex items-center justify-between px-6 py-4">
-        <div className="flex items-center gap-2">
-          <h2 className={menuHeadingTitleClass}>메가존 구내식당</h2>
-          <p className={menuSubheadingClass}>
-            <Clock
-              size={9}
-              strokeWidth={2.5}
-              className="text-muted"
-              aria-hidden
-            />
-            <span>{CAFETERIA_LABEL}</span>
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={() => goToToday()}
-          aria-hidden={selectedDate.isSame(today, 'day')}
-          className={todayButtonClass(selectedDate.isSame(today, 'day'))}
-        >
-          <CalendarDays size={11} strokeWidth={2.5} />
-          오늘
-        </button>
+      <div className="flex items-center gap-2 px-6 py-4">
+        <h2 className={menuHeadingTitleClass}>메가존 구내식당</h2>
+        <p className={menuSubheadingClass}>
+          <Clock
+            size={9}
+            strokeWidth={2.5}
+            className="text-muted"
+            aria-hidden
+          />
+          <span>{CAFETERIA_LABEL}</span>
+        </p>
       </div>
       <MenuBoardDayBar />
       <div ref={menuBodyRef} className={menuBodyClass}>

--- a/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.styles.ts
@@ -27,7 +27,7 @@ export const voteGroupClass =
 export const itemsTextClass =
   'mt-2 flex flex-wrap gap-x-0.5 text-ink text-[14.5px] leading-relaxed font-semibold';
 
-export const itemNameClass = 'whitespace-nowrap';
+export const itemNameClass = 'break-words';
 
 export const itemKcalClass =
   'text-muted ml-0.5 text-[10px] font-semibold not-italic';

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -9,8 +9,11 @@ export const weekRangeClass =
 
 export const chipAreaClass = 'flex items-center gap-2 px-4 pb-2.5';
 
-export const navButtonClass =
-  'flex min-h-[44px] w-8 shrink-0 items-center justify-center text-muted transition-opacity duration-100 hover:text-ink active:scale-75 disabled:cursor-default disabled:opacity-20 disabled:hover:text-muted';
+export const navButtonClass = (canGo: boolean) =>
+  cn(
+    'flex min-h-[44px] w-8 shrink-0 cursor-pointer items-center justify-center transition-opacity duration-100 active:scale-75',
+    canGo ? 'text-muted hover:text-ink' : 'cursor-default opacity-25'
+  );
 
 export const navArrowClass = 'text-[16px] leading-none font-light';
 

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -9,11 +9,12 @@ export const weekRangeClass =
 
 export const navButtonClass = (visible: boolean) =>
   cn(
-    'group relative flex cursor-pointer items-center justify-center px-1 py-2 text-muted transition-opacity duration-100 hover:text-ink active:scale-75',
+    'group relative flex cursor-pointer items-center justify-center px-1 py-2 text-muted transition-opacity duration-100 hover:text-ink',
     !visible && 'invisible pointer-events-none'
   );
 
-export const navArrowClass = 'text-[14px] leading-none font-light';
+export const navArrowClass =
+  'text-[14px] leading-none font-light transition-transform group-active:scale-75';
 
 export const navTooltipClass =
   'pointer-events-none absolute top-full left-1/2 z-10 mt-1.5 -translate-x-1/2 whitespace-nowrap bg-ink px-2 py-1 text-[10px] font-medium text-cream invisible opacity-0 transition-opacity group-hover:visible group-hover:opacity-100';

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -7,10 +7,10 @@ export const weekLabelClass = 'flex items-center gap-1 px-4 pt-1.5 pb-0.5';
 export const weekRangeClass =
   'flex-1 text-center text-[11px] font-semibold tabular-nums text-muted';
 
-export const navButtonClass = (canGo: boolean) =>
+export const navButtonClass = (visible: boolean) =>
   cn(
-    'flex cursor-pointer items-center justify-center px-1 py-2 transition-opacity duration-100 active:scale-75',
-    canGo ? 'text-muted hover:text-ink' : 'cursor-default opacity-25'
+    'flex cursor-pointer items-center justify-center px-1 py-2 text-muted transition-opacity duration-100 hover:text-ink active:scale-75',
+    !visible && 'invisible pointer-events-none'
   );
 
 export const navArrowClass = 'text-[14px] leading-none font-light';

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -9,11 +9,14 @@ export const weekRangeClass =
 
 export const navButtonClass = (visible: boolean) =>
   cn(
-    'flex cursor-pointer items-center justify-center px-1 py-2 text-muted transition-opacity duration-100 hover:text-ink active:scale-75',
+    'group relative flex cursor-pointer items-center justify-center px-1 py-2 text-muted transition-opacity duration-100 hover:text-ink active:scale-75',
     !visible && 'invisible pointer-events-none'
   );
 
 export const navArrowClass = 'text-[14px] leading-none font-light';
+
+export const navTooltipClass =
+  'pointer-events-none absolute top-full left-1/2 z-10 mt-1.5 -translate-x-1/2 whitespace-nowrap bg-ink px-2 py-1 text-[10px] font-medium text-cream invisible opacity-0 transition-opacity group-hover:visible group-hover:opacity-100';
 
 export const chipAreaClass = 'px-4 pb-2.5';
 

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -2,10 +2,13 @@ import { cn } from '@/utils/cn';
 
 export const dayBarContainerClass = 'bg-surface flex flex-col';
 
-export const weekLabelClass = 'px-4 pt-2.5 pb-0.5';
+export const weekLabelClass = 'flex items-center px-4 pt-2.5 pb-0.5';
 
 export const weekRangeClass =
-  'block text-center text-[11px] font-semibold tabular-nums text-muted';
+  'flex-1 text-center text-[11px] font-semibold tabular-nums text-muted';
+
+export const todayChipClass =
+  'text-[10px] font-bold text-accent-text transition-opacity hover:opacity-70 active:scale-90 animate-[fadeIn_0.2s_ease_both]';
 
 export const chipAreaClass = 'flex items-center gap-2 px-4 pb-2.5';
 

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -2,20 +2,19 @@ import { cn } from '@/utils/cn';
 
 export const dayBarContainerClass = 'bg-surface flex flex-col';
 
-export const weekHeaderClass = 'flex items-center px-4 pb-2';
+export const weekLabelClass = 'px-4 pt-2.5 pb-0.5';
 
 export const weekRangeClass =
-  'flex-1 text-center text-[13px] font-bold text-ink';
+  'text-[11px] font-semibold tabular-nums text-muted';
 
-export const navButtonClass = (canGo: boolean) =>
-  cn(
-    'flex min-h-[44px] w-8 shrink-0 cursor-pointer items-center justify-center transition-opacity duration-100 active:scale-75',
-    canGo ? 'text-muted hover:text-ink' : 'cursor-default opacity-25'
-  );
+export const chipAreaClass = 'flex items-center gap-2 px-4 pb-2.5';
+
+export const navButtonClass =
+  'flex min-h-[44px] w-8 shrink-0 items-center justify-center text-muted transition-opacity duration-100 hover:text-ink active:scale-75 disabled:cursor-default disabled:opacity-20 disabled:hover:text-muted';
 
 export const navArrowClass = 'text-[16px] leading-none font-light';
 
-export const chipRowClass = 'relative flex gap-1.5 overflow-hidden';
+export const chipRowClass = 'relative flex flex-1 gap-1.5 overflow-hidden';
 
 export const indicatorClass = (isToday: boolean) =>
   cn(

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -2,25 +2,22 @@ import { cn } from '@/utils/cn';
 
 export const dayBarContainerClass = 'bg-surface flex flex-col';
 
-export const weekLabelClass = 'flex items-center px-4 pt-2.5 pb-0.5';
+export const weekLabelClass = 'flex items-center gap-1 px-4 pt-1.5 pb-0.5';
 
 export const weekRangeClass =
   'flex-1 text-center text-[11px] font-semibold tabular-nums text-muted';
 
-export const todayChipClass =
-  'text-[10px] font-bold text-accent-text transition-opacity hover:opacity-70 active:scale-90 animate-[fadeIn_0.2s_ease_both]';
-
-export const chipAreaClass = 'flex items-center gap-2 px-4 pb-2.5';
-
 export const navButtonClass = (canGo: boolean) =>
   cn(
-    'flex min-h-[44px] w-8 shrink-0 cursor-pointer items-center justify-center transition-opacity duration-100 active:scale-75',
+    'flex cursor-pointer items-center justify-center px-1 py-2 transition-opacity duration-100 active:scale-75',
     canGo ? 'text-muted hover:text-ink' : 'cursor-default opacity-25'
   );
 
-export const navArrowClass = 'text-[16px] leading-none font-light';
+export const navArrowClass = 'text-[14px] leading-none font-light';
 
-export const chipRowClass = 'relative flex flex-1 gap-1.5 overflow-hidden';
+export const chipAreaClass = 'px-4 pb-2.5';
+
+export const chipRowClass = 'relative flex gap-1.5 overflow-hidden';
 
 export const indicatorClass = (isToday: boolean) =>
   cn(

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -39,6 +39,7 @@ export const labelClass = (
   dow: number
 ): string => {
   if (isSelected) return isToday ? 'text-ink/55' : 'text-cream-2';
+  if (isToday) return 'text-accent-text';
   return dowColor(dow) ?? 'text-muted';
 };
 
@@ -48,5 +49,6 @@ export const dateClass = (
   dow: number
 ): string => {
   if (isSelected) return isToday ? 'text-ink' : 'text-cream';
+  if (isToday) return 'text-accent-text';
   return dowColor(dow) ?? 'text-ink';
 };

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -5,7 +5,7 @@ export const dayBarContainerClass = 'bg-surface flex flex-col';
 export const weekLabelClass = 'px-4 pt-2.5 pb-0.5';
 
 export const weekRangeClass =
-  'text-[11px] font-semibold tabular-nums text-muted';
+  'block text-center text-[11px] font-semibold tabular-nums text-muted';
 
 export const chipAreaClass = 'flex items-center gap-2 px-4 pb-2.5';
 

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -1,15 +1,27 @@
 import { cn } from '@/utils/cn';
 
-export const dayBarContainerClass =
-  'bg-surface flex items-center gap-2 px-4 py-3';
+export const dayBarContainerClass = 'bg-surface flex flex-col';
+
+export const weekHeaderClass = 'flex items-center px-4 pb-2';
+
+export const weekRangeClass =
+  'flex-1 text-center text-[13px] font-bold text-ink';
 
 export const navButtonClass = (canGo: boolean) =>
   cn(
-    'flex min-h-[44px] w-8 shrink-0 cursor-pointer flex-col items-center justify-center gap-0.5 transition-opacity duration-100 active:scale-75',
+    'flex min-h-[44px] w-8 shrink-0 cursor-pointer items-center justify-center transition-opacity duration-100 active:scale-75',
     canGo ? 'text-muted hover:text-ink' : 'cursor-default opacity-25'
   );
 
 export const navArrowClass = 'text-[16px] leading-none font-light';
+
+export const chipRowClass = 'relative flex gap-1.5 overflow-hidden';
+
+export const indicatorClass = (isToday: boolean) =>
+  cn(
+    'pointer-events-none absolute inset-y-0 transition-transform duration-200 ease-out',
+    isToday ? 'bg-accent' : 'bg-ink'
+  );
 
 export const chipBg = (isSelected: boolean): string => {
   if (!isSelected) return 'hover:bg-surface-warm';

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import toast from 'react-hot-toast';
-
 import { useHasMounted } from '@/hooks/useHasMounted';
 import { useDateStore } from '@/store/useDateStore';
 
@@ -33,28 +31,12 @@ const MenuBoardDayBar = () => {
   const canGoPrev = !mounted || currentWeek[0].isAfter(minDate, 'day');
   const canGoNext = !mounted || currentWeek[6].isBefore(maxDate, 'day');
 
-  const handlePrev = () => {
-    if (!canGoPrev) {
-      toast.error('제공하지 않는 날짜예요');
-      return;
-    }
-    goToPrevWeek();
-  };
-
-  const handleNext = () => {
-    if (!canGoNext) {
-      toast.error('아직 준비 중이에요');
-      return;
-    }
-    goToNextWeek();
-  };
-
   return (
     <div className={dayBarContainerClass}>
       <div className={weekLabelClass}>
         <button
           type="button"
-          onClick={handlePrev}
+          onClick={goToPrevWeek}
           aria-label="지난주 메뉴 보기"
           className={navButtonClass(canGoPrev)}
         >
@@ -67,7 +49,7 @@ const MenuBoardDayBar = () => {
         </span>
         <button
           type="button"
-          onClick={handleNext}
+          onClick={goToNextWeek}
           aria-label="다음 주 메뉴 보기"
           className={navButtonClass(canGoNext)}
         >

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -6,9 +6,13 @@ import { useHasMounted } from '@/hooks/useHasMounted';
 import { useDateStore } from '@/store/useDateStore';
 
 import {
+  chipRowClass,
   dayBarContainerClass,
+  indicatorClass,
   navArrowClass,
   navButtonClass,
+  weekHeaderClass,
+  weekRangeClass,
 } from './MenuBoardDayBar.styles';
 import MenuBoardDayChip from './MenuBoardDayChip';
 
@@ -46,18 +50,33 @@ const MenuBoardDayBar = () => {
 
   return (
     <div className={dayBarContainerClass}>
-      <button
-        type="button"
-        onClick={handlePrev}
-        aria-label="지난주 메뉴 보기"
-        className={navButtonClass(canGoPrev)}
-      >
-        <span className={navArrowClass}>‹</span>
-      </button>
-      <div className="flex flex-1 flex-col">
+      <div className={weekHeaderClass}>
+        <button
+          type="button"
+          onClick={handlePrev}
+          aria-label="지난주 메뉴 보기"
+          className={navButtonClass(canGoPrev)}
+        >
+          <span className={navArrowClass}>‹</span>
+        </button>
+        <span suppressHydrationWarning className={weekRangeClass}>
+          {mounted
+            ? `${currentWeek[0].format('M월 D일')} - ${currentWeek[6].format('M월 D일')}`
+            : ''}
+        </span>
+        <button
+          type="button"
+          onClick={handleNext}
+          aria-label="다음 주 메뉴 보기"
+          className={navButtonClass(canGoNext)}
+        >
+          <span className={navArrowClass}>›</span>
+        </button>
+      </div>
+      <div className="pb-2">
         <div
           key={currentWeek[0]?.format('YYYY-MM-DD')}
-          className="relative flex gap-1.5 overflow-hidden"
+          className={chipRowClass}
           style={{ animation: 'fadeIn 0.2s ease both' }}
         >
           {(() => {
@@ -68,7 +87,7 @@ const MenuBoardDayBar = () => {
             return idx >= 0 ? (
               <div
                 aria-hidden
-                className={`pointer-events-none absolute inset-y-0 transition-transform duration-200 ease-out ${isToday ? 'bg-accent' : 'bg-ink'}`}
+                className={indicatorClass(isToday)}
                 style={{
                   width: 'calc((100% - 36px) / 7)',
                   transform: `translateX(calc(${idx} * (100% + 6px)))`,
@@ -88,14 +107,6 @@ const MenuBoardDayBar = () => {
           ))}
         </div>
       </div>
-      <button
-        type="button"
-        onClick={handleNext}
-        aria-label="다음 주 메뉴 보기"
-        className={navButtonClass(canGoNext)}
-      >
-        <span className={navArrowClass}>›</span>
-      </button>
     </div>
   );
 };

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import toast from 'react-hot-toast';
+
 import { useHasMounted } from '@/hooks/useHasMounted';
 import { useDateStore } from '@/store/useDateStore';
 
@@ -31,6 +33,22 @@ const MenuBoardDayBar = () => {
   const canGoPrev = !mounted || currentWeek[0].isAfter(minDate, 'day');
   const canGoNext = !mounted || currentWeek[6].isBefore(maxDate, 'day');
 
+  const handlePrev = () => {
+    if (!canGoPrev) {
+      toast.error('제공하지 않는 날짜예요');
+      return;
+    }
+    goToPrevWeek();
+  };
+
+  const handleNext = () => {
+    if (!canGoNext) {
+      toast.error('아직 준비 중이에요');
+      return;
+    }
+    goToNextWeek();
+  };
+
   return (
     <div className={dayBarContainerClass}>
       <div className={weekLabelClass}>
@@ -43,10 +61,9 @@ const MenuBoardDayBar = () => {
       <div className={chipAreaClass}>
         <button
           type="button"
-          disabled={!canGoPrev}
-          onClick={goToPrevWeek}
+          onClick={handlePrev}
           aria-label="지난주 메뉴 보기"
-          className={navButtonClass}
+          className={navButtonClass(canGoPrev)}
         >
           <span className={navArrowClass}>‹</span>
         </button>
@@ -85,9 +102,9 @@ const MenuBoardDayBar = () => {
         <button
           type="button"
           disabled={!canGoNext}
-          onClick={goToNextWeek}
+          onClick={handleNext}
           aria-label="다음 주 메뉴 보기"
-          className={navButtonClass}
+          className={navButtonClass(canGoNext)}
         >
           <span className={navArrowClass}>›</span>
         </button>

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -12,7 +12,6 @@ import {
   indicatorClass,
   navArrowClass,
   navButtonClass,
-  todayChipClass,
   weekLabelClass,
   weekRangeClass,
 } from './MenuBoardDayBar.styles';
@@ -26,7 +25,6 @@ const MenuBoardDayBar = () => {
     minDate,
     maxDate,
     setSelectedDate,
-    goToToday,
     goToPrevWeek,
     goToNextWeek,
   } = useDateStore();
@@ -54,28 +52,6 @@ const MenuBoardDayBar = () => {
   return (
     <div className={dayBarContainerClass}>
       <div className={weekLabelClass}>
-        <div className="w-8" />
-        <span suppressHydrationWarning className={weekRangeClass}>
-          {mounted
-            ? `${currentWeek[0].format('M월 D일')} - ${currentWeek[6].format('M월 D일')}`
-            : ''}
-        </span>
-        <div className="flex w-8 justify-end">
-          {mounted &&
-            (!selectedDate.isSame(today, 'day') ||
-              !currentWeek.some((d) => d.isSame(today, 'day'))) && (
-              <button
-                type="button"
-                onClick={goToToday}
-                aria-label="오늘로 이동"
-                className={todayChipClass}
-              >
-                오늘
-              </button>
-            )}
-        </div>
-      </div>
-      <div className={chipAreaClass}>
         <button
           type="button"
           onClick={handlePrev}
@@ -84,6 +60,21 @@ const MenuBoardDayBar = () => {
         >
           <span className={navArrowClass}>‹</span>
         </button>
+        <span suppressHydrationWarning className={weekRangeClass}>
+          {mounted
+            ? `${currentWeek[0].format('M월 D일')} - ${currentWeek[6].format('M월 D일')}`
+            : ''}
+        </span>
+        <button
+          type="button"
+          onClick={handleNext}
+          aria-label="다음 주 메뉴 보기"
+          className={navButtonClass(canGoNext)}
+        >
+          <span className={navArrowClass}>›</span>
+        </button>
+      </div>
+      <div className={chipAreaClass}>
         <div
           key={currentWeek[0]?.format('YYYY-MM-DD')}
           className={chipRowClass}
@@ -116,15 +107,6 @@ const MenuBoardDayBar = () => {
             />
           ))}
         </div>
-        <button
-          type="button"
-          disabled={!canGoNext}
-          onClick={handleNext}
-          aria-label="다음 주 메뉴 보기"
-          className={navButtonClass(canGoNext)}
-        >
-          <span className={navArrowClass}>›</span>
-        </button>
       </div>
     </div>
   );

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -34,10 +34,8 @@ const MenuBoardDayBar = () => {
 
   const isCurrentWeek =
     mounted && currentWeek.some((d) => d.isSame(today, 'day'));
-  const isPrevWeek =
-    mounted && !isCurrentWeek && currentWeek[0].isBefore(today, 'day');
-  const prevLabel = isPrevWeek ? '이번주' : '지난주';
-  const nextLabel = isCurrentWeek || isPrevWeek ? '다음주' : '이번주';
+  const prevLabel = isCurrentWeek ? '지난주' : '이번주';
+  const nextLabel = isCurrentWeek ? '다음주' : '이번주';
 
   return (
     <div className={dayBarContainerClass}>

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -1,17 +1,16 @@
 'use client';
 
-import toast from 'react-hot-toast';
-
 import { useHasMounted } from '@/hooks/useHasMounted';
 import { useDateStore } from '@/store/useDateStore';
 
 import {
+  chipAreaClass,
   chipRowClass,
   dayBarContainerClass,
   indicatorClass,
   navArrowClass,
   navButtonClass,
-  weekHeaderClass,
+  weekLabelClass,
   weekRangeClass,
 } from './MenuBoardDayBar.styles';
 import MenuBoardDayChip from './MenuBoardDayChip';
@@ -32,48 +31,25 @@ const MenuBoardDayBar = () => {
   const canGoPrev = !mounted || currentWeek[0].isAfter(minDate, 'day');
   const canGoNext = !mounted || currentWeek[6].isBefore(maxDate, 'day');
 
-  const handlePrev = () => {
-    if (!canGoPrev) {
-      toast.error('제공하지 않는 날짜예요');
-      return;
-    }
-    goToPrevWeek();
-  };
-
-  const handleNext = () => {
-    if (!canGoNext) {
-      toast.error('아직 준비 중이에요');
-      return;
-    }
-    goToNextWeek();
-  };
-
   return (
     <div className={dayBarContainerClass}>
-      <div className={weekHeaderClass}>
-        <button
-          type="button"
-          onClick={handlePrev}
-          aria-label="지난주 메뉴 보기"
-          className={navButtonClass(canGoPrev)}
-        >
-          <span className={navArrowClass}>‹</span>
-        </button>
+      <div className={weekLabelClass}>
         <span suppressHydrationWarning className={weekRangeClass}>
           {mounted
             ? `${currentWeek[0].format('M월 D일')} - ${currentWeek[6].format('M월 D일')}`
             : ''}
         </span>
+      </div>
+      <div className={chipAreaClass}>
         <button
           type="button"
-          onClick={handleNext}
-          aria-label="다음 주 메뉴 보기"
-          className={navButtonClass(canGoNext)}
+          disabled={!canGoPrev}
+          onClick={goToPrevWeek}
+          aria-label="지난주 메뉴 보기"
+          className={navButtonClass}
         >
-          <span className={navArrowClass}>›</span>
+          <span className={navArrowClass}>‹</span>
         </button>
-      </div>
-      <div className="pb-2">
         <div
           key={currentWeek[0]?.format('YYYY-MM-DD')}
           className={chipRowClass}
@@ -106,6 +82,15 @@ const MenuBoardDayBar = () => {
             />
           ))}
         </div>
+        <button
+          type="button"
+          disabled={!canGoNext}
+          onClick={goToNextWeek}
+          aria-label="다음 주 메뉴 보기"
+          className={navButtonClass}
+        >
+          <span className={navArrowClass}>›</span>
+        </button>
       </div>
     </div>
   );

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -10,6 +10,7 @@ import {
   indicatorClass,
   navArrowClass,
   navButtonClass,
+  navTooltipClass,
   weekLabelClass,
   weekRangeClass,
 } from './MenuBoardDayBar.styles';
@@ -31,6 +32,13 @@ const MenuBoardDayBar = () => {
   const canGoPrev = !mounted || currentWeek[0].isAfter(minDate, 'day');
   const canGoNext = !mounted || currentWeek[6].isBefore(maxDate, 'day');
 
+  const isCurrentWeek =
+    mounted && currentWeek.some((d) => d.isSame(today, 'day'));
+  const isPrevWeek =
+    mounted && !isCurrentWeek && currentWeek[0].isBefore(today, 'day');
+  const prevLabel = isPrevWeek ? '이번주' : '지난주';
+  const nextLabel = isCurrentWeek || isPrevWeek ? '다음주' : '이번주';
+
   return (
     <div className={dayBarContainerClass}>
       <div className={weekLabelClass}>
@@ -41,6 +49,7 @@ const MenuBoardDayBar = () => {
           className={navButtonClass(canGoPrev)}
         >
           <span className={navArrowClass}>‹</span>
+          <span className={navTooltipClass}>{prevLabel}</span>
         </button>
         <span suppressHydrationWarning className={weekRangeClass}>
           {mounted
@@ -54,6 +63,7 @@ const MenuBoardDayBar = () => {
           className={navButtonClass(canGoNext)}
         >
           <span className={navArrowClass}>›</span>
+          <span className={navTooltipClass}>{nextLabel}</span>
         </button>
       </div>
       <div className={chipAreaClass}>

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -12,6 +12,7 @@ import {
   indicatorClass,
   navArrowClass,
   navButtonClass,
+  todayChipClass,
   weekLabelClass,
   weekRangeClass,
 } from './MenuBoardDayBar.styles';
@@ -25,6 +26,7 @@ const MenuBoardDayBar = () => {
     minDate,
     maxDate,
     setSelectedDate,
+    goToToday,
     goToPrevWeek,
     goToNextWeek,
   } = useDateStore();
@@ -52,11 +54,26 @@ const MenuBoardDayBar = () => {
   return (
     <div className={dayBarContainerClass}>
       <div className={weekLabelClass}>
+        <div className="w-8" />
         <span suppressHydrationWarning className={weekRangeClass}>
           {mounted
             ? `${currentWeek[0].format('M월 D일')} - ${currentWeek[6].format('M월 D일')}`
             : ''}
         </span>
+        <div className="flex w-8 justify-end">
+          {mounted &&
+            (!selectedDate.isSame(today, 'day') ||
+              !currentWeek.some((d) => d.isSame(today, 'day'))) && (
+              <button
+                type="button"
+                onClick={goToToday}
+                aria-label="오늘로 이동"
+                className={todayChipClass}
+              >
+                오늘
+              </button>
+            )}
+        </div>
       </div>
       <div className={chipAreaClass}>
         <button

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayChip.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayChip.styles.ts
@@ -2,10 +2,17 @@ import { cn } from '@/utils/cn';
 
 import { chipBg, labelClass, dateClass } from './MenuBoardDayBar.styles';
 
-export const chipButtonClass = (isSelected: boolean, justSelected: boolean) =>
+export const chipButtonClass = (
+  isSelected: boolean,
+  isToday: boolean,
+  justSelected: boolean
+) =>
   cn(
     'relative flex min-h-[44px] flex-1 cursor-pointer flex-col items-center justify-center gap-0.5 transition-colors duration-150 active:opacity-70',
     chipBg(isSelected),
+    isToday &&
+      !isSelected &&
+      "after:absolute after:bottom-1.5 after:left-1/2 after:size-1 after:-translate-x-1/2 after:bg-accent after:content-['']",
     justSelected && 'animate-[chipPop_0.22s_ease-out]'
   );
 

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayChip.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayChip.tsx
@@ -33,7 +33,7 @@ const MenuBoardDayChip = ({
       type="button"
       onClick={() => onSelect(day)}
       aria-pressed={isSelected}
-      className={chipButtonClass(isSelected, justSelected)}
+      className={chipButtonClass(isSelected, isToday, justSelected)}
     >
       <span
         suppressHydrationWarning

--- a/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.constants.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.constants.ts
@@ -3,6 +3,7 @@ export const BOARD_EMPTY_COPY = {
     label: '휴무',
     title: '구내식당이 쉬는 날이에요',
     body: '인근 식당을 이용해 주세요',
+    bodyPast: '다들 어디서 드셨나요?',
   },
   comingUp: {
     label: '준비 중',

--- a/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
@@ -73,7 +73,9 @@ const MenuBoardEmpty = ({
       <div className="relative">
         <div className={emptyLabelClass}>{copy.label}</div>
         <h3 className={emptyTitleClass}>{closedTitle}</h3>
-        {copy.body && <p className={emptyBodyClass}>{copy.body}</p>}
+        {copy.body && !(variant === 'closed' && isPast) && (
+          <p className={emptyBodyClass}>{copy.body}</p>
+        )}
       </div>
     </div>
   );

--- a/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
@@ -73,8 +73,10 @@ const MenuBoardEmpty = ({
       <div className="relative">
         <div className={emptyLabelClass}>{copy.label}</div>
         <h3 className={emptyTitleClass}>{closedTitle}</h3>
-        {copy.body && !(variant === 'closed' && isPast) && (
-          <p className={emptyBodyClass}>{copy.body}</p>
+        {variant === 'closed' && isPast && 'bodyPast' in copy ? (
+          <p className={emptyBodyClass}>{copy.bodyPast}</p>
+        ) : (
+          copy.body && <p className={emptyBodyClass}>{copy.body}</p>
         )}
       </div>
     </div>

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -1,4 +1,4 @@
-type NavItem = { label: string; href: string };
+type NavItem = { label: string; href: string; comingSoon?: boolean };
 
 export const SITE_NAME = 'MegaBobs';
 
@@ -6,7 +6,7 @@ export const NAV_ITEMS: NavItem[] = [
   { label: '식단표', href: '/' },
   { label: '공지사항', href: '/notice' },
   { label: '메가존 소식', href: '/news' },
-  { label: '미니게임', href: '/games' },
+  { label: '미니게임', href: '/games', comingSoon: true },
 ];
 
 export const FOOTER_LINKS: { label: string; href: string }[] = [

--- a/src/store/useDateStore.ts
+++ b/src/store/useDateStore.ts
@@ -10,7 +10,6 @@ interface DateStore {
   selectedDate: dayjs.Dayjs;
   currentWeek: dayjs.Dayjs[];
   setSelectedDate: (date: dayjs.Dayjs) => void;
-  goToToday: () => void;
   goToPrevWeek: () => void;
   goToNextWeek: () => void;
 }
@@ -28,11 +27,6 @@ export const useDateStore = create<DateStore>((set, get) => {
     currentWeek: getWeekDays(today),
 
     setSelectedDate: (date) => set({ selectedDate: date }),
-
-    goToToday: () => {
-      const { today } = get();
-      set({ selectedDate: today, currentWeek: getWeekDays(today) });
-    },
 
     goToPrevWeek: () => {
       const { currentWeek, minDate } = get();

--- a/src/store/useDateStore.ts
+++ b/src/store/useDateStore.ts
@@ -10,6 +10,7 @@ interface DateStore {
   selectedDate: dayjs.Dayjs;
   currentWeek: dayjs.Dayjs[];
   setSelectedDate: (date: dayjs.Dayjs) => void;
+  goToToday: () => void;
   goToPrevWeek: () => void;
   goToNextWeek: () => void;
 }
@@ -27,6 +28,11 @@ export const useDateStore = create<DateStore>((set, get) => {
     currentWeek: getWeekDays(today),
 
     setSelectedDate: (date) => set({ selectedDate: date }),
+
+    goToToday: () => {
+      const { today } = get();
+      set({ selectedDate: today, currentWeek: getWeekDays(today) });
+    },
 
     goToPrevWeek: () => {
       const { currentWeek, minDate } = get();

--- a/src/store/useDateStore.ts
+++ b/src/store/useDateStore.ts
@@ -32,20 +32,14 @@ export const useDateStore = create<DateStore>((set, get) => {
       const { currentWeek, minDate } = get();
       const prevWeekStart = currentWeek[0].subtract(7, 'day');
       if (prevWeekStart.isBefore(minDate, 'day')) return;
-      set({
-        currentWeek: getWeekDays(prevWeekStart),
-        selectedDate: prevWeekStart,
-      });
+      set({ currentWeek: getWeekDays(prevWeekStart) });
     },
 
     goToNextWeek: () => {
       const { currentWeek, maxDate } = get();
       const nextWeekStart = currentWeek[6].add(1, 'day');
       if (nextWeekStart.isAfter(maxDate, 'day')) return;
-      set({
-        currentWeek: getWeekDays(nextWeekStart),
-        selectedDate: nextWeekStart,
-      });
+      set({ currentWeek: getWeekDays(nextWeekStart) });
     },
   };
 });


### PR DESCRIPTION
## 개요

> **한줄 요약**: DayBar 날짜 내비게이션 UX를 전면 개선하고, 과거 휴무일 빈 상태 문구를 추가했어요

날짜 탐색 시 화살표 위치와 동작 방식이 직관적이지 않다는 피드백을 반영해 DayBar를 개선했어요. 범위 초과 시 toast 대신 화살표를 숨기는 방식으로 전환하고, hover 툴팁을 추가해 탐색 가능 범위를 명확하게 안내해요. 과거 휴무일에는 숨겨졌던 안내 문구 자리에 '다들 어디서 드셨나요?'를 노출해요.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **DayBar 내비게이션** | `MenuBoardDayBar.tsx`, `MenuBoardDayBar.styles.ts` | 화살표를 날짜 레이블 양옆으로 이동, hover 툴팁 추가, 범위 초과 시 숨김 처리 |
| **오늘 칩 강조** | `MenuBoardDayChip.tsx`, `MenuBoardDayChip.styles.ts` | 오늘 날짜 칩 특별 강조 표시 |
| **빈 상태 문구** | `MenuBoardEmpty.constants.ts`, `MenuBoardEmpty.tsx` | 과거 휴무일에 `bodyPast` 문구 노출 |
| **날짜 상태 관리** | `useDateStore.ts` | 주 이동 시 selectedDate 변경 제거 — 탐색만 수행 |
| **피드백 팝업** | `RenewalFeedbackPopup.tsx`, `useRenewalFeedback.ts` | 한국 IP 제한·geo 저장 개선 |
| **모바일 수정** | `MenuBoardCourseRow.styles.ts` | 긴 메뉴명 잘림 현상 수정 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 사용자
    participant DayBar
    participant DateStore

    사용자->>DayBar: 화살표 클릭 (범위 내)
    DayBar->>DateStore: goToPrevWeek / goToNextWeek
    DateStore-->>DayBar: currentWeek 업데이트 (selectedDate 유지)
    DayBar-->>사용자: 주 이동 (날짜 선택 유지)

    사용자->>DayBar: 화살표 hover (범위 경계)
    DayBar-->>사용자: 툴팁 표시 ("이번 주", "다음 주")
```

&nbsp;

## 주요 리뷰 요청사항

- 주 이동 시 `selectedDate`를 변경하지 않는 방식으로 변경했는데, 탐색과 선택의 분리가 자연스러운지 확인해 주세요

&nbsp;

## 테스트 계획

- [ ] 이전 주 화살표 클릭 시 날짜 선택 유지, 주만 이동 확인
- [ ] 범위 최솟값(1주 전 월요일)에서 이전 화살표 숨김 확인
- [ ] 범위 최댓값(1주 후 일요일)에서 다음 화살표 숨김 확인
- [ ] 화살표 hover 시 툴팁 노출 확인
- [ ] 과거 휴무일 빈 상태에서 '다들 어디서 드셨나요?' 문구 표시 확인
- [ ] 현재/미래 휴무일 빈 상태에서 '인근 식당을 이용해 주세요' 유지 확인
- [ ] 모바일에서 긴 메뉴명 줄임 표시 확인
- [ ] 기존 기능 미영향 확인

---

> 🎭 **오늘의 커밋 시**
>
> 화살표는 날짜 곁으로 자리를 옮겼고 🏹
> 범위를 넘으면 조용히 사라져요
> 쉬는 날엔 "다들 어디서 드셨나요?" 😄
> 툴팁은 갈 곳을 귓속말해주고
> 선택은 그대로, 탐색만 흘러가요 🗓️

🤖 Generated with [Claude Code](https://claude.com/claude-code)