### PR TITLE
[codex] 메뉴 미등록 상태를 휴무와 구분

### DIFF
--- a/src/components/menu/MenuBoard/MenuBoard.tsx
+++ b/src/components/menu/MenuBoard/MenuBoard.tsx
@@ -11,7 +11,7 @@ import { useVotes } from '@/hooks/useVote';
 import dayjs from '@/lib/dayjs';
 import { useDateStore } from '@/store/useDateStore';
 import { formatYYYYMMDD } from '@/utils/date';
-import { isAfterClose, isNextWeekMenuLocked } from '@/utils/menuPolicy';
+import { isAfterClose, isFutureMenuPending } from '@/utils/menuPolicy';
 
 import MenuBoardCourseRow from './_MenuBoardCourseRow/MenuBoardCourseRow';
 import MenuBoardDayBar from './_MenuBoardDayBar/MenuBoardDayBar';
@@ -56,7 +56,7 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
     ).filter((m): m is NonNullable<typeof m> => Boolean(m));
   }, [menus, selectedDate]);
 
-  const emptyVariant = isNextWeekMenuLocked(selectedDate, now)
+  const emptyVariant = isFutureMenuPending(selectedDate, now)
     ? 'comingUp'
     : 'closed';
 

--- a/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.constants.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.constants.ts
@@ -6,8 +6,8 @@ export const BOARD_EMPTY_COPY = {
     bodyPast: '다들 어디서 드셨나요?',
   },
   comingUp: {
-    label: '준비 중',
-    title: '영양사 선생님이 메뉴를 고민하고 있어요',
-    body: '목요일에 다시 확인해 주세요',
+    label: '메뉴 준비 중',
+    title: '다음 주 메뉴를 준비하고 있어요',
+    body: '매주 목요일에 업데이트돼요',
   },
 } as const;

--- a/src/utils/menuPolicy.ts
+++ b/src/utils/menuPolicy.ts
@@ -1,25 +1,5 @@
 import { CAFETERIA_CLOSE_MIN } from '@/constants/cafeteria';
 import dayjs from '@/lib/dayjs';
-import { getWeekDays } from '@/utils/date';
-
-/** 매주 목요일부터 다음 주 메뉴 공개 (0=일, 4=목) */
-const NEXT_WEEK_PUBLICATION_DOW = 4;
-
-/** @internal 월요일 시작 주의 첫날. getWeekDays와 동일 기준. */
-const startOfWeekMon = (d: dayjs.Dayjs) => getWeekDays(d)[0];
-
-/** date가 today 기준 다음 주에 속하는지 반환한다. */
-const isNextWeek = (date: dayjs.Dayjs, today: dayjs.Dayjs) =>
-  startOfWeekMon(date).isSame(startOfWeekMon(today).add(7, 'day'), 'day');
-
-/**
- * 다음 주 메뉴 공개 여부를 반환한다.
- * 매주 목요일부터 공개 — 목(4)·금(5)·토(6)·일(0) = true.
- */
-const isNextWeekPublished = (now: dayjs.Dayjs) => {
-  const d = now.day();
-  return d === 0 || d >= NEXT_WEEK_PUBLICATION_DOW;
-};
 
 /** 구내식당 영업 종료 시각 이후인지 반환한다. */
 export const isAfterClose = (now: dayjs.Dayjs) => {
@@ -27,8 +7,16 @@ export const isAfterClose = (now: dayjs.Dayjs) => {
   return nowMin >= CAFETERIA_CLOSE_MIN;
 };
 
-/** selectedDate가 다음 주이고 아직 메뉴가 비공개 상태인지 반환한다. */
-export const isNextWeekMenuLocked = (
+/**
+ * 메뉴 데이터가 없는 미래 평일을 미등록 상태로 분류한다.
+ * 오늘·과거와 주말은 실제 휴무일 수 있으므로 미등록으로 간주하지 않는다.
+ */
+export const isFutureMenuPending = (
   selectedDate: dayjs.Dayjs,
   now: dayjs.Dayjs
-) => isNextWeek(selectedDate, now) && !isNextWeekPublished(now);
+) => {
+  const day = selectedDate.day();
+  const isWeekend = day === 0 || day === 6;
+
+  return selectedDate.isAfter(now, 'day') && !isWeekend;
+};


### PR DESCRIPTION
## 변경 사항

- 메뉴 데이터가 없는 미래 평일을 휴무가 아닌 메뉴 준비 상태로 분류했습니다.
- 오늘, 과거 날짜, 주말의 데이터 부재는 기존처럼 휴무로 표시합니다.
- 준비 상태 문구에 매주 목요일 업데이트 일정을 명시했습니다.

## 원인

기존 로직은 다음 주 메뉴 공개 기준일이 지난 뒤에도 데이터가 없으면 해당 날짜를 무조건 휴무로 분류했습니다. 메뉴 업데이트가 지연된 경우와 실제 휴무를 구분하지 못해 잘못된 안내가 표시됐습니다.

## 영향

다음 주 메뉴가 아직 등록되지 않은 경우 사용자는 휴무 대신 메뉴 준비 안내를 확인합니다.

## 검증

- `pnpm test` — 4개 테스트 통과
- `pnpm build` — 프로덕션 빌드 통과

Closes #62
