### PR TITLE
fix: [메뉴판] 미등록 메뉴를 휴무와 구분

### DIFF
--- a/src/components/menu/MenuBoard/MenuBoard.tsx
+++ b/src/components/menu/MenuBoard/MenuBoard.tsx
@@ -11,7 +11,7 @@ import { useVotes } from '@/hooks/useVote';
 import dayjs from '@/lib/dayjs';
 import { useDateStore } from '@/store/useDateStore';
 import { formatYYYYMMDD } from '@/utils/date';
-import { isAfterClose, isNextWeekMenuLocked } from '@/utils/menuPolicy';
+import { isAfterClose, isFutureMenuPending } from '@/utils/menuPolicy';
 
 import MenuBoardCourseRow from './_MenuBoardCourseRow/MenuBoardCourseRow';
 import MenuBoardDayBar from './_MenuBoardDayBar/MenuBoardDayBar';
@@ -56,7 +56,7 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
     ).filter((m): m is NonNullable<typeof m> => Boolean(m));
   }, [menus, selectedDate]);
 
-  const emptyVariant = isNextWeekMenuLocked(selectedDate, now)
+  const emptyVariant = isFutureMenuPending(selectedDate, now)
     ? 'comingUp'
     : 'closed';
 

--- a/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.constants.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.constants.ts
@@ -6,8 +6,8 @@ export const BOARD_EMPTY_COPY = {
     bodyPast: '다들 어디서 드셨나요?',
   },
   comingUp: {
-    label: '준비 중',
-    title: '영양사 선생님이 메뉴를 고민하고 있어요',
-    body: '목요일에 다시 확인해 주세요',
+    label: '메뉴 준비 중',
+    title: '다음 주 메뉴를 준비하고 있어요',
+    body: '매주 목요일에 업데이트돼요',
   },
 } as const;

--- a/src/utils/menuPolicy.ts
+++ b/src/utils/menuPolicy.ts
@@ -1,25 +1,5 @@
 import { CAFETERIA_CLOSE_MIN } from '@/constants/cafeteria';
 import dayjs from '@/lib/dayjs';
-import { getWeekDays } from '@/utils/date';
-
-/** 매주 목요일부터 다음 주 메뉴 공개 (0=일, 4=목) */
-const NEXT_WEEK_PUBLICATION_DOW = 4;
-
-/** @internal 월요일 시작 주의 첫날. getWeekDays와 동일 기준. */
-const startOfWeekMon = (d: dayjs.Dayjs) => getWeekDays(d)[0];
-
-/** date가 today 기준 다음 주에 속하는지 반환한다. */
-const isNextWeek = (date: dayjs.Dayjs, today: dayjs.Dayjs) =>
-  startOfWeekMon(date).isSame(startOfWeekMon(today).add(7, 'day'), 'day');
-
-/**
- * 다음 주 메뉴 공개 여부를 반환한다.
- * 매주 목요일부터 공개 — 목(4)·금(5)·토(6)·일(0) = true.
- */
-const isNextWeekPublished = (now: dayjs.Dayjs) => {
-  const d = now.day();
-  return d === 0 || d >= NEXT_WEEK_PUBLICATION_DOW;
-};
 
 /** 구내식당 영업 종료 시각 이후인지 반환한다. */
 export const isAfterClose = (now: dayjs.Dayjs) => {
@@ -27,8 +7,16 @@ export const isAfterClose = (now: dayjs.Dayjs) => {
   return nowMin >= CAFETERIA_CLOSE_MIN;
 };
 
-/** selectedDate가 다음 주이고 아직 메뉴가 비공개 상태인지 반환한다. */
-export const isNextWeekMenuLocked = (
+/**
+ * 메뉴 데이터가 없는 미래 평일을 미등록 상태로 분류한다.
+ * 오늘·과거와 주말은 실제 휴무일 수 있으므로 미등록으로 간주하지 않는다.
+ */
+export const isFutureMenuPending = (
   selectedDate: dayjs.Dayjs,
   now: dayjs.Dayjs
-) => isNextWeek(selectedDate, now) && !isNextWeekPublished(now);
+) => {
+  const day = selectedDate.day();
+  const isWeekend = day === 0 || day === 6;
+
+  return selectedDate.isAfter(now, 'day') && !isWeekend;
+};


### PR DESCRIPTION
## 개요

> **한줄 요약**: 메뉴가 등록되지 않은 미래 평일을 휴무가 아닌 준비 상태로 안내합니다.

다음 주 메뉴 업데이트가 늦어질 때 해당 날짜가 휴무로 잘못 표시되는 문제를 해결합니다. 실제 메뉴 데이터의 존재 여부와 날짜를 기준으로 안내 상태를 명확히 구분합니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **메뉴 상태 정책** | `menuPolicy.ts` | 미래 평일의 메뉴 부재를 준비 상태로 분류 |
| **메뉴판 상태 연결** | `MenuBoard.tsx` | 새로운 메뉴 준비 상태 판별 정책 적용 |
| **안내 문구** | `MenuBoardEmpty.constants.ts` | 매주 목요일 업데이트 일정 안내 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 사용자
    participant 메뉴판
    participant 상태정책
    participant 빈화면

    사용자->>메뉴판: 메뉴가 없는 날짜 선택
    메뉴판->>상태정책: 선택 날짜와 현재 시각 전달
    alt 미래 평일
        상태정책-->>메뉴판: 메뉴 준비 중
        메뉴판->>빈화면: 목요일 업데이트 안내
    else 오늘·과거·주말
        상태정책-->>메뉴판: 휴무
        메뉴판->>빈화면: 휴무 안내
    end
```

&nbsp;

## 주요 리뷰 요청사항

- 메뉴 데이터가 없는 모든 미래 평일을 준비 상태로 처리하는 정책이 적절한지 확인해 주세요.
- 오늘·과거·주말의 데이터 부재를 기존처럼 휴무로 처리하는지 확인해 주세요.

&nbsp;

## 테스트 계획

- [x] 기존 단위 테스트 실행
- [x] TypeScript 타입 검사
- [x] 프로덕션 빌드
- [ ] 미래 평일에 메뉴 준비 문구가 표시되는지 확인
- [ ] 오늘·과거·주말의 휴무 표시가 유지되는지 확인

---

> 🎭 **오늘의 커밋 시**
>
> 비어 있는 식판을 휴무라 부르지 않고  
> 목요일 소식을 조용히 기다립니다  
> 날짜는 상태를 나누고  
> 메뉴판은 사실만 전합니다 🍚

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #62
