### PR TITLE
release: v1.0.1 프로덕션 릴리스 (dev → main)

### DIFF
--- a/src/components/menu/MenuBoard/MenuBoard.tsx
+++ b/src/components/menu/MenuBoard/MenuBoard.tsx
@@ -32,13 +32,14 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
     () => menus.some((m) => m.date === dateStr && m.items.length > 0),
     [menus, dateStr]
   );
-  const { voteMap, submitVote, isSubmitting } = useVotes(dateStr, {
+  const { voteMap, submitVote, isLoading, isSubmitting } = useVotes(dateStr, {
     enabled: hasMenus,
   });
   const {
     myPick,
     counts,
     submitPick,
+    isLoading: isLoadingPick,
     isSubmitting: isSubmittingPick,
   } = usePick(dateStr, { enabled: hasMenus });
   const now = dayjs().tz();
@@ -101,13 +102,13 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
                 key={menu.category}
                 menu={menu}
                 vote={{
-                  show: showVote,
+                  show: showVote && !isLoading,
                   result: voteMap[menuKey],
                   onVote: (type: 'up' | 'down') => submitVote(menuKey, type),
                   isSubmitting,
                 }}
                 pick={{
-                  show: showPick,
+                  show: showPick && !isLoadingPick,
                   count: counts[menu.category],
                   isPicked: myPick === menu.category,
                   hasAnyPick: myPick !== null,

--- a/src/components/menu/MenuBoard/MenuBoard.tsx
+++ b/src/components/menu/MenuBoard/MenuBoard.tsx
@@ -11,7 +11,7 @@ import { useVotes } from '@/hooks/useVote';
 import dayjs from '@/lib/dayjs';
 import { useDateStore } from '@/store/useDateStore';
 import { formatYYYYMMDD } from '@/utils/date';
-import { isAfterClose, isNextWeekMenuLocked } from '@/utils/menuPolicy';
+import { isAfterClose, isFutureMenuPending } from '@/utils/menuPolicy';
 
 import MenuBoardCourseRow from './_MenuBoardCourseRow/MenuBoardCourseRow';
 import MenuBoardDayBar from './_MenuBoardDayBar/MenuBoardDayBar';
@@ -57,7 +57,7 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
     ).filter((m): m is NonNullable<typeof m> => Boolean(m));
   }, [menus, selectedDate]);
 
-  const emptyVariant = isNextWeekMenuLocked(selectedDate, now)
+  const emptyVariant = isFutureMenuPending(selectedDate, now)
     ? 'comingUp'
     : 'closed';
 

--- a/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.constants.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.constants.ts
@@ -6,8 +6,8 @@ export const BOARD_EMPTY_COPY = {
     bodyPast: '다들 어디서 드셨나요?',
   },
   comingUp: {
-    label: '준비 중',
-    title: '영양사 선생님이 메뉴를 고민하고 있어요',
-    body: '목요일에 다시 확인해 주세요',
+    label: '메뉴 준비 중',
+    title: '다음 주 메뉴를 준비하고 있어요',
+    body: '매주 목요일에 업데이트돼요',
   },
 } as const;

--- a/src/hooks/usePick.ts
+++ b/src/hooks/usePick.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { sendGAEvent } from '@next/third-parties/google';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { PickResult, PickType } from '@/models/vote';
 import { getOrCreateVoterId } from '@/utils/voterId';
@@ -12,46 +12,64 @@ const DEFAULT_COUNTS: PickResult['counts'] = {
   TAKE_OUT: 0,
   pass: 0,
 };
+const EMPTY_PICK_STATE: PickResult = {
+  date: '',
+  counts: DEFAULT_COUNTS,
+  myPick: null,
+};
 
 export const usePick = (date: string, { enabled = true } = {}) => {
-  const [myPick, setMyPick] = useState<PickType | null>(null);
-  const [counts, setCounts] = useState<PickResult['counts']>(DEFAULT_COUNTS);
-  const [isLoading, setIsLoading] = useState(true);
+  const [pickState, setPickState] = useState<PickResult>(EMPTY_PICK_STATE);
+  const [isFetching, setIsFetching] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const requestIdRef = useRef(0);
+  const activeDateRef = useRef(date);
+  activeDateRef.current = date;
+
+  const activePick =
+    enabled && pickState.date === date ? pickState : EMPTY_PICK_STATE;
+  const { myPick, counts } = activePick;
+  const isLoading =
+    enabled && Boolean(date) && (pickState.date !== date || isFetching);
 
   useEffect(() => {
+    const requestId = ++requestIdRef.current;
     if (!date || !enabled) {
-      setIsLoading(false);
+      setIsFetching(false);
       return;
     }
-    let cancelled = false;
+
+    const controller = new AbortController();
 
     const fetchPick = async () => {
       const voterId = getOrCreateVoterId();
       if (!voterId) {
-        setIsLoading(false);
+        setPickState({ ...EMPTY_PICK_STATE, date });
+        setIsFetching(false);
         return;
       }
-      setIsLoading(true);
+
+      setIsFetching(true);
       try {
         const res = await fetch(`/api/picks?date=${date}`, {
           headers: { 'x-voter-id': voterId },
+          signal: controller.signal,
         });
-        if (!res.ok || cancelled) return;
+        if (!res.ok) throw new Error('pick fetch failed');
         const data: PickResult = await res.json();
-        setMyPick(data.myPick);
-        setCounts(data.counts);
+        if (requestId !== requestIdRef.current) return;
+
+        setPickState({ date, myPick: data.myPick, counts: data.counts });
       } catch {
-        // graceful fallback — keep defaults
+        if (requestId === requestIdRef.current && !controller.signal.aborted)
+          setPickState({ ...EMPTY_PICK_STATE, date });
       } finally {
-        if (!cancelled) setIsLoading(false);
+        if (requestId === requestIdRef.current) setIsFetching(false);
       }
     };
 
     fetchPick();
-    return () => {
-      cancelled = true;
-    };
+    return () => controller.abort();
   }, [date, enabled]);
 
   const submitPick = useCallback(
@@ -63,15 +81,21 @@ export const usePick = (date: string, { enabled = true } = {}) => {
       const prevCounts = { ...counts };
 
       // optimistic update
-      setCounts((c) => {
-        const next = { ...c };
+      setPickState((current) => {
+        const currentPick = current.date === date ? current : EMPTY_PICK_STATE;
+        const next = { ...currentPick.counts };
         if (prev) next[prev] = Math.max(0, next[prev] - 1);
         if (!isSame) next[pick_type] += 1;
-        return next;
+        return {
+          date,
+          counts: next,
+          myPick: isSame ? null : pick_type,
+        };
       });
-      setMyPick(isSame ? null : pick_type);
 
       setIsSubmitting(true);
+      const requestDate = date;
+      const requestId = requestIdRef.current;
       try {
         const res = await fetch('/api/picks', {
           method: 'POST',
@@ -88,8 +112,11 @@ export const usePick = (date: string, { enabled = true } = {}) => {
           date,
         });
       } catch {
-        setCounts(prevCounts);
-        setMyPick(prev);
+        if (
+          activeDateRef.current === requestDate &&
+          requestIdRef.current === requestId
+        )
+          setPickState({ date: requestDate, counts: prevCounts, myPick: prev });
       } finally {
         setIsSubmitting(false);
       }

--- a/src/hooks/useVote.ts
+++ b/src/hooks/useVote.ts
@@ -1,36 +1,65 @@
 import { sendGAEvent } from '@next/third-parties/google';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { VoteResult, VoteType } from '@/models/vote';
 import { getOrCreateVoterId } from '@/utils/voterId';
 
 type VoteMap = Record<string, VoteResult>;
+type VoteState = { date: string; map: VoteMap };
+const EMPTY_VOTE_MAP: VoteMap = {};
 
 export const useVotes = (date: string, { enabled = true } = {}) => {
-  const [voteMap, setVoteMap] = useState<VoteMap>({});
-  const [isLoading, setIsLoading] = useState(false);
+  const [voteState, setVoteState] = useState<VoteState>({ date: '', map: {} });
+  const [isFetching, setIsFetching] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const requestIdRef = useRef(0);
+  const activeDateRef = useRef(date);
+  activeDateRef.current = date;
+
+  const voteMap =
+    enabled && voteState.date === date ? voteState.map : EMPTY_VOTE_MAP;
+  const isLoading =
+    enabled && Boolean(date) && (voteState.date !== date || isFetching);
 
   useEffect(() => {
-    if (!date || !enabled) return;
-    const voterId = getOrCreateVoterId();
-    if (!voterId) return;
+    const requestId = ++requestIdRef.current;
+    if (!date || !enabled) {
+      setIsFetching(false);
+      return;
+    }
 
-    setIsLoading(true);
-    setVoteMap({});
+    const voterId = getOrCreateVoterId();
+    if (!voterId) {
+      setIsFetching(false);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    setIsFetching(true);
     fetch(`/api/votes?date=${date}`, {
       headers: { 'x-voter-id': voterId },
+      signal: controller.signal,
     })
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error('vote fetch failed');
+        return res.json();
+      })
       .then((results: VoteResult[]) => {
+        if (requestId !== requestIdRef.current) return;
+
         const map: VoteMap = {};
         for (const r of results) {
           map[r.menuKey] = r;
         }
-        setVoteMap(map);
+        setVoteState({ date, map });
       })
       .catch(() => {})
-      .finally(() => setIsLoading(false));
+      .finally(() => {
+        if (requestId === requestIdRef.current) setIsFetching(false);
+      });
+
+    return () => controller.abort();
   }, [date, enabled]);
 
   const submitVote = useCallback(
@@ -53,8 +82,9 @@ export const useVotes = (date: string, { enabled = true } = {}) => {
         ) ?? null;
 
       // Optimistic update
-      setVoteMap((prev) => {
-        const next = { ...prev };
+      setVoteState((prev) => {
+        const currentMap = prev.date === date ? prev.map : {};
+        const next = { ...currentMap };
 
         // 이전 투표 메뉴 count 감소
         if (prevVotedKey && next[prevVotedKey]) {
@@ -68,7 +98,7 @@ export const useVotes = (date: string, { enabled = true } = {}) => {
           };
         }
 
-        const c = prev[menuKey] ?? {
+        const c = currentMap[menuKey] ?? {
           menuKey,
           up_count: 0,
           down_count: 0,
@@ -96,7 +126,7 @@ export const useVotes = (date: string, { enabled = true } = {}) => {
           };
         }
 
-        return next;
+        return { date, map: next };
       });
 
       setIsSubmitting(true);
@@ -121,14 +151,25 @@ export const useVotes = (date: string, { enabled = true } = {}) => {
         });
       } catch {
         // 실패 시 서버 상태로 재동기화
+        const requestDate = date;
+        const requestId = requestIdRef.current;
         fetch(`/api/votes?date=${date}`, {
           headers: { 'x-voter-id': voterId },
         })
-          .then((r) => r.json())
+          .then((r) => {
+            if (!r.ok) throw new Error('vote sync failed');
+            return r.json();
+          })
           .then((results: VoteResult[]) => {
+            if (
+              activeDateRef.current !== requestDate ||
+              requestIdRef.current !== requestId
+            )
+              return;
+
             const map: VoteMap = {};
             for (const r of results) map[r.menuKey] = r;
-            setVoteMap(map);
+            setVoteState({ date: requestDate, map });
           })
           .catch(() => {});
       } finally {

--- a/src/utils/menuPolicy.ts
+++ b/src/utils/menuPolicy.ts
@@ -1,25 +1,5 @@
 import { CAFETERIA_CLOSE_MIN } from '@/constants/cafeteria';
 import dayjs from '@/lib/dayjs';
-import { getWeekDays } from '@/utils/date';
-
-/** 매주 목요일부터 다음 주 메뉴 공개 (0=일, 4=목) */
-const NEXT_WEEK_PUBLICATION_DOW = 4;
-
-/** @internal 월요일 시작 주의 첫날. getWeekDays와 동일 기준. */
-const startOfWeekMon = (d: dayjs.Dayjs) => getWeekDays(d)[0];
-
-/** date가 today 기준 다음 주에 속하는지 반환한다. */
-const isNextWeek = (date: dayjs.Dayjs, today: dayjs.Dayjs) =>
-  startOfWeekMon(date).isSame(startOfWeekMon(today).add(7, 'day'), 'day');
-
-/**
- * 다음 주 메뉴 공개 여부를 반환한다.
- * 매주 목요일부터 공개 — 목(4)·금(5)·토(6)·일(0) = true.
- */
-const isNextWeekPublished = (now: dayjs.Dayjs) => {
-  const d = now.day();
-  return d === 0 || d >= NEXT_WEEK_PUBLICATION_DOW;
-};
 
 /** 구내식당 영업 종료 시각 이후인지 반환한다. */
 export const isAfterClose = (now: dayjs.Dayjs) => {
@@ -27,8 +7,16 @@ export const isAfterClose = (now: dayjs.Dayjs) => {
   return nowMin >= CAFETERIA_CLOSE_MIN;
 };
 
-/** selectedDate가 다음 주이고 아직 메뉴가 비공개 상태인지 반환한다. */
-export const isNextWeekMenuLocked = (
+/**
+ * 메뉴 데이터가 없는 미래 평일을 미등록 상태로 분류한다.
+ * 오늘·과거와 주말은 실제 휴무일 수 있으므로 미등록으로 간주하지 않는다.
+ */
+export const isFutureMenuPending = (
   selectedDate: dayjs.Dayjs,
   now: dayjs.Dayjs
-) => isNextWeek(selectedDate, now) && !isNextWeekPublished(now);
+) => {
+  const day = selectedDate.day();
+  const isWeekend = day === 0 || day === 6;
+
+  return selectedDate.isAfter(now, 'day') && !isWeekend;
+};


### PR DESCRIPTION
## 개요

> **한줄 요약**: 메뉴판의 상태 안내와 날짜 전환 데이터 일관성을 개선한 v1.0.1 패치 릴리스입니다.

메뉴 업데이트 전 날짜가 휴무로 잘못 표시되는 문제와 날짜를 빠르게 변경할 때 이전 투표·픽 결과가 노출되는 문제를 수정합니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **메뉴 상태 안내** | `menuPolicy.ts`, `MenuBoardEmpty.constants.ts` | 미래 평일의 메뉴 미등록 상태를 휴무와 구분하고 목요일 업데이트 일정 안내 |
| **투표·픽 데이터 일관성** | `useVote.ts`, `usePick.ts`, `MenuBoard.tsx` | 날짜별 상태 격리와 이전 요청 취소로 오래된 결과 노출 방지 |

&nbsp;

## 주요 리뷰 요청사항

- 없음 (패치 릴리스 PR — 개별 수정 PR 검증 완료)

&nbsp;

## 배포 확인

- [x] 개별 수정 PR을 `dev`에 병합
- [x] 기존 단위 테스트 및 프로덕션 빌드 통과
- [ ] `main` 병합 후 Vercel Production 배포 확인
- [ ] 운영 메뉴판 스모크 테스트

---

> 🎭 **오늘의 커밋 시**
>
> 휴무와 준비 중을 바로 세우고  
> 지나간 응답은 조용히 멈췄습니다  
> 작은 두 버그를 정리한 식판  
> v1.0.1로 다시 문을 엽니다 🍚

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #62
Closes #72
