### PR TITLE
[codex] 날짜별 메뉴 공유 기능 추가

### DIFF
--- a/src/components/menu/MenuBoard/MenuBoard.styles.ts
+++ b/src/components/menu/MenuBoard/MenuBoard.styles.ts
@@ -1,6 +1,10 @@
 export const sectionClass =
   'bg-surface flex flex-col shadow-[var(--shadow-card)]';
 
+export const menuHeaderClass = 'flex items-center gap-2 px-6 py-4';
+
+export const menuHeaderIconClass = 'text-muted';
+
 export const menuHeadingTitleClass =
   'text-ink text-[14px] font-extrabold tracking-wide';
 

--- a/src/components/menu/MenuBoard/MenuBoard.tsx
+++ b/src/components/menu/MenuBoard/MenuBoard.tsx
@@ -1,33 +1,28 @@
 'use client';
 
-import { Clock } from 'lucide-react';
-import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 
-import { CAFETERIA_LABEL } from '@/constants/cafeteria';
 import { MENU_CATEGORIES } from '@/constants/menu';
+import { useAnimatedHeight } from '@/hooks/useAnimatedHeight';
 import { useHasMounted } from '@/hooks/useHasMounted';
 import { usePick } from '@/hooks/usePick';
+import { useSharedDateQuery } from '@/hooks/useSharedDateQuery';
 import { useVotes } from '@/hooks/useVote';
 import dayjs from '@/lib/dayjs';
 import { useDateStore } from '@/store/useDateStore';
-import { formatYYYYMMDD } from '@/utils/date';
 import { isAfterClose, isFutureMenuPending } from '@/utils/menuPolicy';
 
 import MenuBoardCourseRow from './_MenuBoardCourseRow/MenuBoardCourseRow';
 import MenuBoardDayBar from './_MenuBoardDayBar/MenuBoardDayBar';
 import MenuBoardEmpty from './_MenuBoardEmpty/MenuBoardEmpty';
-import {
-  menuBodyClass,
-  menuHeadingTitleClass,
-  menuSubheadingClass,
-  sectionClass,
-} from './MenuBoard.styles';
+import MenuBoardHeader from './_MenuBoardHeader';
+import { menuBodyClass, sectionClass } from './MenuBoard.styles';
 import { MenuBoardProps } from './MenuBoard.types';
 
 const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
   const { today, selectedDate } = useDateStore();
   const mounted = useHasMounted();
-  const dateStr = formatYYYYMMDD(selectedDate);
+  const dateStr = useSharedDateQuery();
   const hasMenus = useMemo(
     () => menus.some((m) => m.date === dateStr && m.items.length > 0),
     [menus, dateStr]
@@ -50,48 +45,21 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
   const showPick = isKorea && mounted && !showVote && !isPast;
 
   const dayMenus = useMemo(() => {
-    const key = formatYYYYMMDD(selectedDate);
-    const found = menus.filter((m) => m.date === key && m.items.length > 0);
+    const found = menus.filter((m) => m.date === dateStr && m.items.length > 0);
     return MENU_CATEGORIES.map((c) =>
       found.find((m) => m.category === c)
     ).filter((m): m is NonNullable<typeof m> => Boolean(m));
-  }, [menus, selectedDate]);
+  }, [menus, dateStr]);
 
   const emptyVariant = isFutureMenuPending(selectedDate, now)
     ? 'comingUp'
     : 'closed';
 
-  const menuBodyRef = useRef<HTMLDivElement>(null);
-  const prevHeightRef = useRef(0);
-
-  useLayoutEffect(() => {
-    const el = menuBodyRef.current;
-    if (!el) return;
-    const next = el.scrollHeight;
-    const prev = prevHeightRef.current;
-    prevHeightRef.current = next;
-    if (!prev || prev === next) return;
-    const a = el.animate([{ height: `${prev}px` }, { height: `${next}px` }], {
-      duration: 280,
-      easing: 'ease-in-out',
-    });
-    return () => a.cancel();
-  }, [dateStr]);
+  const menuBodyRef = useAnimatedHeight<HTMLDivElement>(dateStr);
 
   return (
     <section className={sectionClass}>
-      <div className="flex items-center gap-2 px-6 py-4">
-        <h2 className={menuHeadingTitleClass}>메가존 구내식당</h2>
-        <p className={menuSubheadingClass}>
-          <Clock
-            size={9}
-            strokeWidth={2.5}
-            className="text-muted"
-            aria-hidden
-          />
-          <span>{CAFETERIA_LABEL}</span>
-        </p>
-      </div>
+      <MenuBoardHeader date={dateStr} />
       <MenuBoardDayBar />
       <div ref={menuBodyRef} className={menuBodyClass}>
         {dayMenus.length > 0 ? (

--- a/src/components/menu/MenuBoard/_MenuBoardHeader/MenuBoardHeader.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardHeader/MenuBoardHeader.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Clock } from 'lucide-react';
+
+import MenuBoardShareButton from '@/components/menu/MenuBoard/_MenuBoardShareButton';
+import {
+  menuHeaderClass,
+  menuHeaderIconClass,
+  menuHeadingTitleClass,
+  menuSubheadingClass,
+} from '@/components/menu/MenuBoard/MenuBoard.styles';
+import { CAFETERIA_LABEL } from '@/constants/cafeteria';
+
+import { MenuBoardHeaderProps } from './MenuBoardHeader.types';
+
+const MenuBoardHeader = ({ date }: MenuBoardHeaderProps) => {
+  return (
+    <div className={menuHeaderClass}>
+      <h2 className={menuHeadingTitleClass}>메가존 구내식당</h2>
+      <p className={menuSubheadingClass}>
+        <Clock
+          size={9}
+          strokeWidth={2.5}
+          className={menuHeaderIconClass}
+          aria-hidden
+        />
+        <span>{CAFETERIA_LABEL}</span>
+      </p>
+      <MenuBoardShareButton date={date} />
+    </div>
+  );
+};
+
+export default MenuBoardHeader;

--- a/src/components/menu/MenuBoard/_MenuBoardHeader/MenuBoardHeader.types.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardHeader/MenuBoardHeader.types.ts
@@ -1,0 +1,3 @@
+export interface MenuBoardHeaderProps {
+  date: string;
+}

--- a/src/components/menu/MenuBoard/_MenuBoardHeader/index.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MenuBoardHeader';

--- a/src/components/menu/MenuBoard/_MenuBoardShareButton/MenuBoardShareButton.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardShareButton/MenuBoardShareButton.styles.ts
@@ -1,0 +1,2 @@
+export const shareButtonClass =
+  'ml-auto flex size-11 cursor-pointer items-center justify-center bg-surface-warm text-ink-2 transition-colors duration-150 hover:bg-accent-soft hover:text-accent-text active:opacity-70 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink';

--- a/src/components/menu/MenuBoard/_MenuBoardShareButton/MenuBoardShareButton.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardShareButton/MenuBoardShareButton.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Share2 } from 'lucide-react';
+import toast from 'react-hot-toast';
+
+import { buildDateUrl } from '@/utils/dateQuery';
+
+import { shareButtonClass } from './MenuBoardShareButton.styles';
+import { MenuBoardShareButtonProps } from './MenuBoardShareButton.types';
+
+const MenuBoardShareButton = ({ date }: MenuBoardShareButtonProps) => {
+  const handleShare = async () => {
+    const url = buildDateUrl(window.location.href, { date });
+    const shareData = {
+      title: '메가존 구내식당 메뉴',
+      text: `${date} 메뉴를 확인해보세요.`,
+      url,
+    };
+
+    if (typeof navigator.share === 'function') {
+      try {
+        await navigator.share(shareData);
+        return;
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success('공유 링크를 복사했어요');
+    } catch {
+      toast.error('링크 복사에 실패했어요');
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={`${date} 메뉴 공유`}
+      title="메뉴 공유"
+      className={shareButtonClass}
+      onClick={handleShare}
+    >
+      <Share2 size={17} strokeWidth={2.4} aria-hidden />
+    </button>
+  );
+};
+
+export default MenuBoardShareButton;

--- a/src/components/menu/MenuBoard/_MenuBoardShareButton/MenuBoardShareButton.types.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardShareButton/MenuBoardShareButton.types.ts
@@ -1,0 +1,3 @@
+export interface MenuBoardShareButtonProps {
+  date: string;
+}

--- a/src/components/menu/MenuBoard/_MenuBoardShareButton/index.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardShareButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MenuBoardShareButton';

--- a/src/hooks/useAnimatedHeight.ts
+++ b/src/hooks/useAnimatedHeight.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { useLayoutEffect, useRef } from 'react';
+
+export const useAnimatedHeight = <T extends HTMLElement>(
+  dependency: unknown
+) => {
+  const ref = useRef<T>(null);
+  const prevHeightRef = useRef(0);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const next = el.scrollHeight;
+    const prev = prevHeightRef.current;
+    prevHeightRef.current = next;
+    if (!prev || prev === next) return;
+    const animation = el.animate(
+      [{ height: `${prev}px` }, { height: `${next}px` }],
+      {
+        duration: 280,
+        easing: 'ease-in-out',
+      }
+    );
+    return () => animation.cancel();
+  }, [dependency]);
+
+  return ref;
+};

--- a/src/hooks/useSharedDateQuery.ts
+++ b/src/hooks/useSharedDateQuery.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { useDateStore } from '@/store/useDateStore';
+import { formatYYYYMMDD } from '@/utils/date';
+import {
+  DATE_QUERY_PARAM,
+  buildDateUrl,
+  resolveDateQuery,
+} from '@/utils/dateQuery';
+
+export const useSharedDateQuery = () => {
+  const { today, minDate, maxDate, selectedDate, setSelectedDate } =
+    useDateStore();
+  const [isQueryReady, setIsQueryReady] = useState(false);
+  const dateStr = formatYYYYMMDD(selectedDate);
+
+  const syncSelectedDateFromUrl = useCallback(() => {
+    const queryDate = new URL(window.location.href).searchParams.get(
+      DATE_QUERY_PARAM
+    );
+    setSelectedDate(resolveDateQuery(queryDate, { today, minDate, maxDate }));
+  }, [maxDate, minDate, setSelectedDate, today]);
+
+  useEffect(() => {
+    syncSelectedDateFromUrl();
+    setIsQueryReady(true);
+  }, [syncSelectedDateFromUrl]);
+
+  useEffect(() => {
+    window.addEventListener('popstate', syncSelectedDateFromUrl);
+    return () => {
+      window.removeEventListener('popstate', syncSelectedDateFromUrl);
+    };
+  }, [syncSelectedDateFromUrl]);
+
+  useEffect(() => {
+    if (!isQueryReady) return;
+    const nextUrl = buildDateUrl(window.location.href, { date: dateStr });
+    if (nextUrl === window.location.href) return;
+    window.history.replaceState(window.history.state, '', nextUrl);
+  }, [dateStr, isQueryReady]);
+
+  return dateStr;
+};

--- a/src/store/useDateStore.ts
+++ b/src/store/useDateStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 
 import dayjs from '@/lib/dayjs';
 import { getWeekDays } from '@/utils/date';
+import { isDateWithinBounds } from '@/utils/dateQuery';
 
 interface DateStore {
   today: dayjs.Dayjs;
@@ -26,7 +27,12 @@ export const useDateStore = create<DateStore>((set, get) => {
     selectedDate: today,
     currentWeek: getWeekDays(today),
 
-    setSelectedDate: (date) => set({ selectedDate: date }),
+    setSelectedDate: (date) => {
+      const { selectedDate, minDate, maxDate } = get();
+      if (!isDateWithinBounds(date, minDate, maxDate)) return;
+      if (selectedDate.isSame(date, 'day')) return;
+      set({ selectedDate: date, currentWeek: getWeekDays(date) });
+    },
 
     goToPrevWeek: () => {
       const { currentWeek, minDate } = get();

--- a/src/utils/dateQuery.test.ts
+++ b/src/utils/dateQuery.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import dayjs from '@/lib/dayjs';
+
+import { buildDateUrl, resolveDateQuery } from './dateQuery';
+
+describe('resolveDateQuery', () => {
+  const today = dayjs('2026-06-23').tz();
+  const minDate = dayjs('2026-06-16').tz();
+  const maxDate = dayjs('2026-07-05').tz();
+
+  it('returns the queried date when it is valid and in range', () => {
+    expect(
+      resolveDateQuery('2026-06-30', { today, minDate, maxDate }).format(
+        'YYYY-MM-DD'
+      )
+    ).toBe('2026-06-30');
+  });
+
+  it('falls back to today when the query is invalid', () => {
+    expect(
+      resolveDateQuery('2026-6-30', { today, minDate, maxDate }).format(
+        'YYYY-MM-DD'
+      )
+    ).toBe('2026-06-23');
+  });
+
+  it('falls back to today when the query is outside bounds', () => {
+    expect(
+      resolveDateQuery('2026-07-06', { today, minDate, maxDate }).format(
+        'YYYY-MM-DD'
+      )
+    ).toBe('2026-06-23');
+  });
+});
+
+describe('buildDateUrl', () => {
+  it('sets date while preserving existing query params', () => {
+    expect(
+      buildDateUrl('https://mega-bobs.example/?foo=bar&date=2026-06-22', {
+        date: '2026-06-23',
+      })
+    ).toBe('https://mega-bobs.example/?foo=bar&date=2026-06-23');
+  });
+});

--- a/src/utils/dateQuery.ts
+++ b/src/utils/dateQuery.ts
@@ -1,0 +1,44 @@
+import dayjs from '@/lib/dayjs';
+import { formatYYYYMMDD } from '@/utils/date';
+
+export const DATE_QUERY_PARAM = 'date';
+
+const DATE_QUERY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+interface ResolveDateQueryOptions {
+  today: dayjs.Dayjs;
+  minDate: dayjs.Dayjs;
+  maxDate: dayjs.Dayjs;
+}
+
+interface BuildDateUrlOptions {
+  date: string;
+}
+
+export const isDateWithinBounds = (
+  date: dayjs.Dayjs,
+  minDate: dayjs.Dayjs,
+  maxDate: dayjs.Dayjs
+) => !date.isBefore(minDate, 'day') && !date.isAfter(maxDate, 'day');
+
+export const parseDateQuery = (value: string | null): dayjs.Dayjs | null => {
+  if (!value || !DATE_QUERY_PATTERN.test(value)) return null;
+  const parsed = dayjs.tz(value);
+  if (!parsed.isValid() || formatYYYYMMDD(parsed) !== value) return null;
+  return parsed;
+};
+
+export const resolveDateQuery = (
+  value: string | null,
+  { today, minDate, maxDate }: ResolveDateQueryOptions
+) => {
+  const parsed = parseDateQuery(value);
+  if (!parsed || !isDateWithinBounds(parsed, minDate, maxDate)) return today;
+  return parsed;
+};
+
+export const buildDateUrl = (href: string, { date }: BuildDateUrlOptions) => {
+  const url = new URL(href);
+  url.searchParams.set(DATE_QUERY_PARAM, date);
+  return url.toString();
+};


### PR DESCRIPTION
## Summary
- 선택 날짜를 `date=YYYY-MM-DD` 쿼리 파라미터로 유지하도록 추가했습니다.
- 공유 링크 진입 시 해당 날짜와 주간 범위가 선택되도록 처리했습니다.
- 메뉴판 헤더에 공유 버튼을 추가하고, Web Share API 지원 시 시스템 공유를 사용하며 미지원 환경에서는 클립보드 복사로 fallback합니다.

## Validation
- `vitest run src/utils/dateQuery.test.ts` passed: 4 tests
- `tsc --noEmit --pretty false` passed
- changed-file ESLint passed
- `git diff --check` passed

## Notes
- 모바일 실제 기기 Web Share 동작은 로컬 브라우저 환경상 별도 실기기 QA가 필요합니다.