### PR TITLE
feat: [슬랙] 메뉴 응답 하단에 메가밥스 링크 추가

### DIFF
--- a/src/app/api/slack/_utils.ts
+++ b/src/app/api/slack/_utils.ts
@@ -58,5 +58,9 @@ export const toSlackFormat = (
     return [`*${label}*`, ...lines].join('\n');
   }).join('\n\n');
 
-  return sections ? [header, sections].join('\n\n') : header;
+  const footer = `<https://megabobs.com/|🔗 메뉴 투표하기>`;
+
+  return sections
+    ? [header, sections, footer].join('\n\n')
+    : [header, footer].join('\n\n');
 };

--- a/src/app/api/slack/_utils.ts
+++ b/src/app/api/slack/_utils.ts
@@ -58,7 +58,8 @@ export const toSlackFormat = (
     return [`*${label}*`, ...lines].join('\n');
   }).join('\n\n');
 
-  const footer = `<https://megabobs.com/|🔗 메뉴 투표하기>`;
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://megabobs.com';
+  const footer = `<${siteUrl}|🔗 메뉴 투표하기>`;
 
   return sections
     ? [header, sections, footer].join('\n\n')


### PR DESCRIPTION
## 개요

> **한줄 요약**: 슬랙 메뉴 응답 하단에 메가밥스 사이트 링크 추가

슬랙에서 메뉴를 확인한 뒤 투표·픽 기능을 사용하려면 별도로 사이트에 접속해야 했어요. 응답 하단에 링크를 추가해 사이트로 바로 이동할 수 있게 했어요.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **슬랙 응답** | `_utils.ts` | 메뉴 응답 푸터에 메가밥스 링크 추가 |

&nbsp;

## 테스트 계획

- [ ] 슬랙 커맨드 응답 하단에 링크 노출 확인
- [ ] 메뉴 없는 날(휴무·준비 중)에도 링크 노출 확인
- [ ] 링크 클릭 시 메가밥스 사이트로 정상 이동 확인
- [ ] 기존 메뉴 텍스트 포맷 미영향 확인

---

> 🎭 **오늘의 커밋 시**
>
> 🍚 밥은 봤지, 그 다음은?
> 🔗 링크 하나 슬쩍 달았네
> 투표함이 손짓하고, 픽은 아직 비어있어
> 클릭 한 번이면 충분해 🌐

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)