### PR TITLE
feat: [날짜·공유] URL로 날짜 딥링크 및 메뉴 링크 공유 지원

### DIFF
--- a/src/components/menu/MenuBoard/MenuBoard.tsx
+++ b/src/components/menu/MenuBoard/MenuBoard.tsx
@@ -5,6 +5,7 @@ import { useLayoutEffect, useMemo, useRef } from 'react';
 
 import { CAFETERIA_LABEL } from '@/constants/cafeteria';
 import { MENU_CATEGORIES } from '@/constants/menu';
+import { useDateUrl } from '@/hooks/useDateUrl';
 import { useHasMounted } from '@/hooks/useHasMounted';
 import { usePick } from '@/hooks/usePick';
 import { useVotes } from '@/hooks/useVote';
@@ -25,6 +26,7 @@ import {
 import { MenuBoardProps } from './MenuBoard.types';
 
 const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
+  useDateUrl();
   const { today, selectedDate } = useDateStore();
   const mounted = useHasMounted();
   const dateStr = formatYYYYMMDD(selectedDate);

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -2,7 +2,10 @@ import { cn } from '@/utils/cn';
 
 export const dayBarContainerClass = 'bg-surface flex flex-col';
 
-export const weekLabelClass = 'flex items-center gap-1 px-4 pt-1.5 pb-0.5';
+export const weekLabelClass = 'flex items-center gap-0.5 px-4 pt-1.5 pb-0.5';
+
+export const shareBtnClass =
+  'flex min-h-11 min-w-11 cursor-pointer items-center justify-center text-muted transition-colors duration-100 hover:text-ink focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ink';
 
 export const weekRangeClass =
   'flex-1 text-center text-[11px] font-semibold tabular-nums text-muted';

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -1,9 +1,13 @@
 'use client';
 
 import { sendGAEvent } from '@next/third-parties/google';
+import { Share2 } from 'lucide-react';
+import toast from 'react-hot-toast';
 
 import { useHasMounted } from '@/hooks/useHasMounted';
+import { shareMenuUrl } from '@/lib/share';
 import { useDateStore } from '@/store/useDateStore';
+import { formatYYYYMMDD } from '@/utils/date';
 
 import {
   chipAreaClass,
@@ -13,6 +17,7 @@ import {
   navArrowClass,
   navButtonClass,
   navTooltipClass,
+  shareBtnClass,
   weekLabelClass,
   weekRangeClass,
 } from './MenuBoardDayBar.styles';
@@ -30,6 +35,14 @@ const MenuBoardDayBar = () => {
     goToNextWeek,
   } = useDateStore();
   const mounted = useHasMounted();
+
+  const handleShare = async () => {
+    const dateStr = formatYYYYMMDD(selectedDate);
+    sendGAEvent('event', 'share_menu', { date: dateStr });
+    const result = await shareMenuUrl(dateStr);
+    if (result === 'copied') toast.success('링크 복사됨');
+    if (result === 'error') toast.error('링크 복사 실패');
+  };
 
   const canGoPrev = !mounted || currentWeek[0].isAfter(minDate, 'day');
   const canGoNext = !mounted || currentWeek[6].isBefore(maxDate, 'day');
@@ -70,6 +83,14 @@ const MenuBoardDayBar = () => {
         >
           <span className={navArrowClass}>›</span>
           <span className={navTooltipClass}>{nextLabel}</span>
+        </button>
+        <button
+          type="button"
+          onClick={handleShare}
+          aria-label="메뉴 링크 공유"
+          className={shareBtnClass}
+        >
+          <Share2 size={13} strokeWidth={2} aria-hidden />
         </button>
       </div>
       <div className={chipAreaClass}>

--- a/src/hooks/useDateUrl.ts
+++ b/src/hooks/useDateUrl.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import dayjs from '@/lib/dayjs';
+import { useDateStore } from '@/store/useDateStore';
+import { formatYYYYMMDD } from '@/utils/date';
+
+const DATE_PARAM_FORMAT = 'YYYY-MM-DD';
+
+export const useDateUrl = () => {
+  const { selectedDate, minDate, maxDate, initFromDate } = useDateStore();
+  const mounted = useRef(false);
+
+  useEffect(() => {
+    const dateStr = formatYYYYMMDD(selectedDate);
+    const url = new URL(window.location.href);
+
+    if (!mounted.current) {
+      mounted.current = true;
+      const param = url.searchParams.get('date');
+      if (param) {
+        const parsed = dayjs(param, DATE_PARAM_FORMAT, true).tz();
+        if (
+          parsed.isValid() &&
+          !parsed.isBefore(minDate, 'day') &&
+          !parsed.isAfter(maxDate, 'day')
+        ) {
+          initFromDate(parsed);
+          return;
+        }
+      }
+    }
+
+    url.searchParams.set('date', dateStr);
+    history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
+    // minDate, maxDate, initFromDate are stable store values — intentionally omitted
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedDate]);
+};

--- a/src/lib/dayjs.ts
+++ b/src/lib/dayjs.ts
@@ -1,8 +1,10 @@
 import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
 import 'dayjs/locale/ko';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 
+dayjs.extend(customParseFormat);
 dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.locale('ko');

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,0 +1,23 @@
+export type ShareResult = 'shared' | 'copied' | 'cancelled' | 'error';
+
+export const shareMenuUrl = async (dateStr: string): Promise<ShareResult> => {
+  const shareUrl = new URL(window.location.href);
+  shareUrl.searchParams.set('date', dateStr);
+  const url = shareUrl.toString();
+
+  if (navigator.share) {
+    try {
+      await navigator.share({ title: `메가존 구내식당 ${dateStr}`, url });
+      return 'shared';
+    } catch (e) {
+      if (e instanceof Error && e.name === 'AbortError') return 'cancelled';
+    }
+  }
+
+  try {
+    await navigator.clipboard.writeText(url);
+    return 'copied';
+  } catch {
+    return 'error';
+  }
+};

--- a/src/store/useDateStore.ts
+++ b/src/store/useDateStore.ts
@@ -10,6 +10,7 @@ interface DateStore {
   selectedDate: dayjs.Dayjs;
   currentWeek: dayjs.Dayjs[];
   setSelectedDate: (date: dayjs.Dayjs) => void;
+  initFromDate: (date: dayjs.Dayjs) => void;
   goToPrevWeek: () => void;
   goToNextWeek: () => void;
 }
@@ -27,6 +28,9 @@ export const useDateStore = create<DateStore>((set, get) => {
     currentWeek: getWeekDays(today),
 
     setSelectedDate: (date) => set({ selectedDate: date }),
+
+    initFromDate: (date) =>
+      set({ selectedDate: date, currentWeek: getWeekDays(date) }),
 
     goToPrevWeek: () => {
       const { currentWeek, minDate } = get();


### PR DESCRIPTION
## 개요

> **한줄 요약**: 선택한 날짜를 URL `?date=` 파라미터로 동기화하고, DayBar에 공유 버튼을 추가해 특정 날짜 메뉴 링크를 공유할 수 있게 합니다.

날짜를 선택해도 URL이 바뀌지 않아 공유하거나 새로고침하면 항상 오늘 날짜로 돌아오는 문제가 있었습니다.
이번 변경으로 `?date=YYYY-MM-DD` 파라미터가 자동으로 유지되며, 공유 버튼으로 해당 날짜 링크를 바로 전달할 수 있습니다.

Closes #69

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
|---|---|---|
| **인프라** | `dayjs.ts`, `useDateStore.ts` | customParseFormat 플러그인 등록, `initFromDate` 액션 추가 |
| **URL 동기화** | `useDateUrl.ts`, `MenuBoard.tsx` | 마운트 시 `?date=` 파라미터 읽기 + `selectedDate` 변경 시 URL 쓰기 |
| **공유 버튼** | `share.ts`, `MenuBoardDayBar.tsx`, `MenuBoardDayBar.styles.ts` | DayBar 우측 공유 버튼 (Web Share API → 클립보드 폴백) |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 브라우저
    participant useDateUrl
    participant Store
    participant DayBar
    participant share.ts

    브라우저->>useDateUrl: 마운트 (?date=2026-06-25)
    useDateUrl->>Store: initFromDate(parsed)
    Store-->>useDateUrl: selectedDate 변경
    useDateUrl->>브라우저: replaceState(?date=2026-06-25)

    Note over 브라우저,Store: 날짜 탐색 시
    Store-->>useDateUrl: selectedDate 변경
    useDateUrl->>브라우저: replaceState(?date=새날짜)

    Note over DayBar,share.ts: 공유 버튼 클릭 시
    DayBar->>share.ts: shareMenuUrl(dateStr)
    share.ts->>브라우저: navigator.share() or clipboard.writeText()
    share.ts-->>DayBar: 'shared' | 'copied' | 'cancelled' | 'error'
```

&nbsp;

## 주요 리뷰 요청사항

- **double-click race**: `handleShare`에 in-flight 가드가 없어 빠른 이중 클릭 시 clipboard.writeText가 두 번 호출될 수 있습니다 (창이 매우 좁아 실사용 영향은 미미하나 인지 필요)

&nbsp;

## 테스트 계획

- [ ] `?date=2026-06-23` 직접 URL 접속 → 해당 날짜로 초기화 확인
- [ ] 날짜 범위 밖 파라미터(`?date=2020-01-01`) → 무시되고 오늘 날짜로 fallback 확인
- [ ] 날짜 탭 클릭 시 URL이 `?date=YYYY-MM-DD`로 갱신 확인
- [ ] 새로고침 후 선택 날짜 유지 확인
- [ ] 공유 버튼 클릭 → 모바일: Web Share Sheet, 데스크톱: 클립보드 복사 + 토스트 확인
- [ ] 잘못된 날짜 형식 파라미터(`?date=abc`) → 오류 없이 오늘 날짜 표시 확인
- [ ] 기존 날짜 탐색(prev/next 주 이동) 정상 동작 확인

---

> 🎭 **오늘의 커밋 시**
>
> 🔗 URL 속에 날짜를 심었네,
> 📅 새로고침해도 기억하리라.
> 📤 공유 버튼 하나로 밥벗 부르고,
> 🍱 오늘 메뉴 링크 슬쩍 건네봐.
> 📌 히스토리엔 흔적이 남고, 클립보드엔 URL이 남네.

🤖 Generated with [Claude Code](https://claude.com/claude-code)