### PR TITLE
feat: [홈] 홈 진입 시간대별 문구·아이콘 세분화

### DIFF
--- a/src/components/home/HeroStatus/HeroStatus.utils.ts
+++ b/src/components/home/HeroStatus/HeroStatus.utils.ts
@@ -1,6 +1,5 @@
-import { Clock, Moon, Sun, Utensils } from 'lucide-react';
+import { Clock, Coffee, Moon, Sun, Utensils } from 'lucide-react';
 import type { ElementType } from 'react';
-
 
 import {
   CAFETERIA_CLOSE_MIN,
@@ -51,12 +50,27 @@ export const getHeroStatus = (
       : { icon: Sun, text: '오늘은 공휴일이에요', variant: 'closed' };
   }
 
+  const MORNING_START = 7 * 60; // 07:00
+  const PRE_LUNCH_START = 10 * 60; // 10:00
+  const EVENING_START = 18 * 60; // 18:00
+
+  if (min < MORNING_START)
+    return { icon: Moon, text: '편안한 밤 되세요', variant: 'closed' };
+
+  if (min < PRE_LUNCH_START)
+    return {
+      icon: Sun,
+      text: '좋은 아침이에요! 오늘 메뉴를 확인해보세요',
+      variant: 'upcoming',
+    };
+
   if (min < CAFETERIA_OPEN_MIN)
     return {
       icon: Clock,
       text: '잠시 후 운영 시작이에요',
       variant: 'upcoming',
     };
+
   if (min < CAFETERIA_CLOSE_MIN)
     return {
       icon: Utensils,
@@ -64,22 +78,42 @@ export const getHeroStatus = (
       variant: 'open',
     };
 
+  if (min < EVENING_START) {
+    if (dow === 5) {
+      return hasMenu(nextWorkdayKey(now))
+        ? {
+            icon: Coffee,
+            text: '오늘 점심은 끝났어요. 월요일에 만나요!',
+            variant: 'closed',
+          }
+        : { icon: Sun, text: '즐거운 주말 되세요!', variant: 'closed' };
+    }
+    const tomorrowKey = formatYYYYMMDD(now.add(1, 'day'));
+    return hasMenu(tomorrowKey)
+      ? {
+          icon: Coffee,
+          text: '오늘 점심은 끝났어요. 내일 만나요!',
+          variant: 'closed',
+        }
+      : { icon: Coffee, text: '오늘 점심은 끝났어요', variant: 'closed' };
+  }
+
   if (dow === 5) {
     return hasMenu(nextWorkdayKey(now))
       ? {
           icon: Moon,
-          text: '오늘 점심은 끝났어요. 월요일에 만나요!',
+          text: '오늘 하루도 수고하셨어요! 월요일에 만나요!',
           variant: 'closed',
         }
-      : { icon: Sun, text: '즐거운 주말 되세요!', variant: 'closed' };
+      : { icon: Moon, text: '즐거운 주말 되세요!', variant: 'closed' };
   }
 
   const tomorrowKey = formatYYYYMMDD(now.add(1, 'day'));
   return hasMenu(tomorrowKey)
     ? {
         icon: Moon,
-        text: '오늘 점심은 끝났어요. 내일 만나요!',
+        text: '오늘 하루도 수고하셨어요! 내일 만나요!',
         variant: 'closed',
       }
-    : { icon: Moon, text: '오늘 점심은 끝났어요', variant: 'closed' };
+    : { icon: Moon, text: '오늘 하루도 수고하셨어요!', variant: 'closed' };
 };

--- a/src/components/home/HeroStatus/HeroStatus.utils.ts
+++ b/src/components/home/HeroStatus/HeroStatus.utils.ts
@@ -86,7 +86,7 @@ export const getHeroStatus = (
             text: '오늘 점심은 끝났어요. 월요일에 만나요!',
             variant: 'closed',
           }
-        : { icon: Sun, text: '즐거운 주말 되세요!', variant: 'closed' };
+        : { icon: Moon, text: '즐거운 주말 되세요!', variant: 'closed' };
     }
     const tomorrowKey = formatYYYYMMDD(now.add(1, 'day'));
     return hasMenu(tomorrowKey)


### PR DESCRIPTION
## 개요

> **한줄 요약**: 평일 홈 진입 문구를 6개 시간대로 세분화하고 각 시간대에 맞는 아이콘 적용

기존에는 평일 자정~11시(11시간)가 동일한 "잠시 후 운영 시작이에요" 문구를,
13시~자정(10시간)이 동일한 "오늘 점심은 끝났어요" 문구를 공유해 맥락이 맞지 않았습니다.
사용자 접속 시점에 어울리는 인사말로 세분화합니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **홈 상태 로직** | `HeroStatus.utils.ts` | 평일 시간대 6구간 분리 및 아이콘 매핑 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 사용자
    participant HeroStatus
    participant utils as getHeroStatus

    사용자->>HeroStatus: 홈 진입 (60초마다 갱신)
    HeroStatus->>utils: dayjs().tz() 전달
    utils-->>HeroStatus: { icon, text, variant }
    Note over utils: 00~07 Moon 편안한 밤<br/>07~10 Sun 좋은 아침<br/>10~11 Clock 운영 직전<br/>11~13:15 Utensils 운영 중<br/>13:15~18 Coffee 점심 마감<br/>18~ Moon 수고하셨어요
    HeroStatus-->>사용자: 시간대 맞춤 문구·아이콘 렌더
```

&nbsp;

## 테스트 계획

- [ ] 각 시간대 경계(00:00, 07:00, 10:00, 11:00, 13:15, 18:00)에서 올바른 문구·아이콘 확인
- [ ] 평일 / 금요일 / 주말 / 공휴일 분기 미영향 확인
- [ ] 기존 운영 중 애니메이션(softPulse) 정상 동작 확인
- [ ] 기존 기능 미영향 확인

---

> 🎭 **오늘의 커밋 시**
>
> 자정엔 달이 뜨고 ☾, 아침엔 해가 빛나고 ☀️
> 열한시엔 밥솥이 딸깍 🍽️, 오후엔 커피향이 ☕
> 저녁엔 달빛 아래 퇴근길 🌙
> 메가밥스는 언제나 당신 곁에 🍱

🤖 Generated with [Claude Code](https://claude.com/claude-code)