### PR TITLE
feat: [공지] 공지 확인 시 벨 dot·NEW 배지 읽음 처리

### DIFF
--- a/src/app/notice/[id]/page.tsx
+++ b/src/app/notice/[id]/page.tsx
@@ -4,9 +4,10 @@ import { notFound } from 'next/navigation';
 import { getNoticeById, getNotices } from '@/api/getNotices';
 import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
 import NoticeBody from '@/components/notice/NoticeBody';
+import NoticeReadMarker from '@/components/notice/NoticeReadMarker';
 import { SITE_NAME } from '@/constants/site';
-import { getBreadcrumbJsonLd } from '@/utils/jsonLd';
 import { formatRelativeDate } from '@/utils/date';
+import { getBreadcrumbJsonLd } from '@/utils/jsonLd';
 
 import { contentClass } from './page.styles';
 import type { PageProps } from './page.types';
@@ -63,6 +64,7 @@ const NoticeDetailPage = async ({ params }: PageProps) => {
         )}
       >
         <div className={contentClass}>
+          <NoticeReadMarker id={notice.id} />
           <NoticeBody body={notice.body} />
         </div>
       </PageLayout>

--- a/src/app/notice/page.styles.ts
+++ b/src/app/notice/page.styles.ts
@@ -13,9 +13,6 @@ export const articleYearClass = 'text-muted block text-[11px]';
 export const articleTitleClass =
   'flex items-center gap-2 overflow-hidden text-base font-extrabold';
 
-export const newBadgeClass =
-  'bg-accent text-ink px-1.5 py-0.5 text-[9.5px] font-extrabold';
-
 export const articleBodyClass =
   'text-ink-2 mt-1.5 line-clamp-2 text-[13.5px] leading-relaxed';
 

--- a/src/app/notice/page.tsx
+++ b/src/app/notice/page.tsx
@@ -3,11 +3,13 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import { getNotices } from '@/api/getNotices';
-import { stripMarkdown } from '@/utils/stripMarkdown';
 import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
+import NoticeNewBadge from '@/components/notice/NoticeNewBadge';
 import { SITE_NAME } from '@/constants/site';
 import dayjs from '@/lib/dayjs';
 import { getBreadcrumbJsonLd } from '@/utils/jsonLd';
+import { NEW_NOTICE_THRESHOLD_DAYS } from '@/utils/noticePolicy';
+import { stripMarkdown } from '@/utils/stripMarkdown';
 
 import {
   articleBodyClass,
@@ -16,7 +18,6 @@ import {
   articleTitleClass,
   articleYearClass,
   emptyNoticeClass,
-  newBadgeClass,
 } from './page.styles';
 
 const noticeDesc = `${SITE_NAME} 구내식당 앱의 새 기능 소식, 점검 일정, 운영 안내를 확인하세요.`;
@@ -67,7 +68,8 @@ export default function NoticePage() {
           <div className="flex flex-col">
             {notices.map((n, i) => {
               const isNew =
-                dayjs().tz().diff(dayjs.tz(n.publishedAt), 'day') < 7;
+                dayjs().tz().diff(dayjs.tz(n.publishedAt), 'day') <
+                NEW_NOTICE_THRESHOLD_DAYS;
               return (
                 <Link
                   key={n.id}
@@ -85,7 +87,7 @@ export default function NoticePage() {
                   <div className="min-w-0 flex-1">
                     <h3 className={articleTitleClass}>
                       <span className="truncate">{n.title}</span>
-                      {isNew && <span className={newBadgeClass}>NEW</span>}
+                      <NoticeNewBadge noticeId={n.id} isNew={isNew} />
                     </h3>
                     <p className={articleBodyClass}>{stripMarkdown(n.body)}</p>
                   </div>

--- a/src/components/@shared/layout/SiteHeader/SiteHeader.tsx
+++ b/src/components/@shared/layout/SiteHeader/SiteHeader.tsx
@@ -3,12 +3,18 @@
 import { Bell, Check, Menu, X } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import {
+  type Dispatch,
+  type SetStateAction,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 import { getNotices } from '@/api/getNotices';
 import { NAV_ITEMS, SITE_NAME } from '@/constants/site';
 import { useHasMounted } from '@/hooks/useHasMounted';
-import { hasNewNotice } from '@/utils/noticePolicy';
+import { getReadNoticeIds, hasNewNotice } from '@/utils/noticePolicy';
 
 import {
   bellDotClass,
@@ -27,17 +33,151 @@ import {
   mobileOverlayClass,
 } from './SiteHeader.styles';
 
+const NoticeBell = ({
+  showNoticeDot,
+  className,
+  prefetch,
+}: {
+  showNoticeDot: boolean;
+  className: string;
+  prefetch: (href: string) => void;
+}) => (
+  <Link
+    href="/notice"
+    title="공지사항"
+    aria-label="공지사항"
+    onMouseEnter={() => prefetch('/notice')}
+    className={className}
+  >
+    <span className={bellSpanClass(showNoticeDot)}>
+      <Bell size={17} strokeWidth={2.2} />
+    </span>
+    {showNoticeDot && <span aria-hidden className={bellDotClass} />}
+  </Link>
+);
+
+const DesktopNav = ({
+  pathname,
+  prefetch,
+}: {
+  pathname: string;
+  prefetch: (href: string) => void;
+}) => (
+  <nav className={desktopNavClass}>
+    {NAV_ITEMS.map((item) => {
+      if (item.comingSoon) {
+        return (
+          <span key={item.href} className={desktopComingSoonClass}>
+            {item.label}
+            <span className={comingSoonBadgeClass}>준비중</span>
+          </span>
+        );
+      }
+      const active = pathname === item.href;
+      return (
+        <Link
+          key={item.href}
+          href={item.href}
+          onMouseEnter={() => prefetch(item.href)}
+          className={desktopNavLinkClass(active)}
+        >
+          {item.label}
+        </Link>
+      );
+    })}
+  </nav>
+);
+
+const MobileControls = ({
+  menuOpen,
+  setMenuOpen,
+  showNoticeDot,
+  prefetch,
+}: {
+  menuOpen: boolean;
+  setMenuOpen: Dispatch<SetStateAction<boolean>>;
+  showNoticeDot: boolean;
+  prefetch: (href: string) => void;
+}) => (
+  <div className="ml-auto flex items-center gap-1 min-[641px]:hidden">
+    <NoticeBell
+      showNoticeDot={showNoticeDot}
+      className={mobileBellLinkClass}
+      prefetch={prefetch}
+    />
+    <button
+      type="button"
+      aria-label={menuOpen ? '메뉴 닫기' : '메뉴 열기'}
+      onClick={() => setMenuOpen((v) => !v)}
+      className={mobileMenuButtonClass}
+    >
+      {menuOpen ? (
+        <X size={20} strokeWidth={2} />
+      ) : (
+        <Menu size={20} strokeWidth={2} />
+      )}
+    </button>
+  </div>
+);
+
+const MobileOverlay = ({
+  menuOpen,
+  pathname,
+  setMenuOpen,
+  prefetch,
+}: {
+  menuOpen: boolean;
+  pathname: string;
+  setMenuOpen: Dispatch<SetStateAction<boolean>>;
+  prefetch: (href: string) => void;
+}) => (
+  <div className={mobileOverlayClass(menuOpen)}>
+    <nav className="mx-auto flex w-[min(880px,calc(100%-40px))] flex-col pt-1 pb-4">
+      {NAV_ITEMS.map((item) => {
+        if (item.comingSoon) {
+          return (
+            <span key={item.href} className={mobileComingSoonClass}>
+              {item.label}
+              <span className={comingSoonBadgeClass}>준비중</span>
+            </span>
+          );
+        }
+        const active = pathname === item.href;
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            onClick={() => setMenuOpen(false)}
+            onMouseEnter={() => prefetch(item.href)}
+            className={mobileNavLinkClass(active)}
+          >
+            {item.label}
+            {active && <Check size={16} strokeWidth={2.5} aria-hidden />}
+          </Link>
+        );
+      })}
+    </nav>
+  </div>
+);
+
 const SiteHeader = () => {
   const pathname = usePathname();
   const router = useRouter();
   const mounted = useHasMounted();
   const notices = useMemo(() => getNotices(), []);
+  const [readIds, setReadIds] = useState<string[]>([]);
   const showNoticeDot = useMemo(
-    () => mounted && hasNewNotice(notices),
-    [mounted, notices]
+    () => mounted && hasNewNotice(notices, readIds),
+    [mounted, notices, readIds]
   );
   const [scrolled, setScrolled] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    if (!mounted) return;
+    setReadIds(getReadNoticeIds());
+  }, [mounted, pathname]);
+
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 8);
     window.addEventListener('scroll', onScroll, { passive: true });
@@ -63,102 +203,32 @@ const SiteHeader = () => {
             {SITE_NAME}
           </Link>
 
-          <nav className={desktopNavClass}>
-            {NAV_ITEMS.map((item) => {
-              if (item.comingSoon) {
-                return (
-                  <span key={item.href} className={desktopComingSoonClass}>
-                    {item.label}
-                    <span className={comingSoonBadgeClass}>준비중</span>
-                  </span>
-                );
-              }
-              const active = pathname === item.href;
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  onMouseEnter={() => router.prefetch(item.href)}
-                  className={desktopNavLinkClass(active)}
-                >
-                  {item.label}
-                </Link>
-              );
-            })}
-          </nav>
+          <DesktopNav pathname={pathname} prefetch={router.prefetch} />
 
           {/* 데스크톱 벨 */}
-          <Link
-            href="/notice"
-            title="공지사항"
-            aria-label="공지사항"
-            onMouseEnter={() => router.prefetch('/notice')}
+          <NoticeBell
+            showNoticeDot={showNoticeDot}
             className={desktopBellLinkClass}
-          >
-            <span className={bellSpanClass(showNoticeDot)}>
-              <Bell size={17} strokeWidth={2.2} />
-            </span>
-            {showNoticeDot && <span aria-hidden className={bellDotClass} />}
-          </Link>
+            prefetch={router.prefetch}
+          />
 
           {/* 모바일 우측 */}
-          <div className="ml-auto flex items-center gap-1 min-[641px]:hidden">
-            <Link
-              href="/notice"
-              title="공지사항"
-              aria-label="공지사항"
-              onMouseEnter={() => router.prefetch('/notice')}
-              className={mobileBellLinkClass}
-            >
-              <span className={bellSpanClass(showNoticeDot)}>
-                <Bell size={17} strokeWidth={2.2} />
-              </span>
-              {showNoticeDot && <span aria-hidden className={bellDotClass} />}
-            </Link>
-            <button
-              type="button"
-              aria-label={menuOpen ? '메뉴 닫기' : '메뉴 열기'}
-              onClick={() => setMenuOpen((v) => !v)}
-              className={mobileMenuButtonClass}
-            >
-              {menuOpen ? (
-                <X size={20} strokeWidth={2} />
-              ) : (
-                <Menu size={20} strokeWidth={2} />
-              )}
-            </button>
-          </div>
+          <MobileControls
+            menuOpen={menuOpen}
+            setMenuOpen={setMenuOpen}
+            showNoticeDot={showNoticeDot}
+            prefetch={router.prefetch}
+          />
         </div>
       </header>
 
       {/* 모바일 메뉴 — header 밖 fixed, stacking context 영향 없음 */}
-      <div className={mobileOverlayClass(menuOpen)}>
-        <nav className="mx-auto flex w-[min(880px,calc(100%-40px))] flex-col pt-1 pb-4">
-          {NAV_ITEMS.map((item) => {
-            if (item.comingSoon) {
-              return (
-                <span key={item.href} className={mobileComingSoonClass}>
-                  {item.label}
-                  <span className={comingSoonBadgeClass}>준비중</span>
-                </span>
-              );
-            }
-            const active = pathname === item.href;
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                onClick={() => setMenuOpen(false)}
-                onMouseEnter={() => router.prefetch(item.href)}
-                className={mobileNavLinkClass(active)}
-              >
-                {item.label}
-                {active && <Check size={16} strokeWidth={2.5} aria-hidden />}
-              </Link>
-            );
-          })}
-        </nav>
-      </div>
+      <MobileOverlay
+        menuOpen={menuOpen}
+        pathname={pathname}
+        setMenuOpen={setMenuOpen}
+        prefetch={router.prefetch}
+      />
     </>
   );
 };

--- a/src/components/notice/NoticeNewBadge/NoticeNewBadge.styles.ts
+++ b/src/components/notice/NoticeNewBadge/NoticeNewBadge.styles.ts
@@ -1,0 +1,2 @@
+export const newBadgeClass =
+  'bg-accent text-ink animate-[fadeIn_0.3s_ease_both] px-1.5 py-0.5 text-[9.5px] font-extrabold';

--- a/src/components/notice/NoticeNewBadge/NoticeNewBadge.tsx
+++ b/src/components/notice/NoticeNewBadge/NoticeNewBadge.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { getReadNoticeIds } from '@/utils/noticePolicy';
+
+import { newBadgeClass } from './NoticeNewBadge.styles';
+
+const NoticeNewBadge = ({
+  noticeId,
+  isNew,
+}: {
+  noticeId: string;
+  isNew: boolean;
+}) => {
+  const [read, setRead] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setRead(getReadNoticeIds().includes(noticeId));
+  }, [noticeId]);
+
+  if (!isNew || read !== false) return null;
+  return <span className={newBadgeClass}>NEW</span>;
+};
+
+export default NoticeNewBadge;

--- a/src/components/notice/NoticeNewBadge/index.ts
+++ b/src/components/notice/NoticeNewBadge/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NoticeNewBadge';

--- a/src/components/notice/NoticeReadMarker/NoticeReadMarker.tsx
+++ b/src/components/notice/NoticeReadMarker/NoticeReadMarker.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { markNoticeRead } from '@/utils/noticePolicy';
+
+const NoticeReadMarker = ({ id }: { id: string }) => {
+  useEffect(() => {
+    markNoticeRead(id);
+  }, [id]);
+
+  return null;
+};
+
+export default NoticeReadMarker;

--- a/src/components/notice/NoticeReadMarker/index.ts
+++ b/src/components/notice/NoticeReadMarker/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NoticeReadMarker';

--- a/src/utils/noticePolicy.ts
+++ b/src/utils/noticePolicy.ts
@@ -1,11 +1,36 @@
 import dayjs from '@/lib/dayjs';
 import type { Notice } from '@/models/notice';
 
-const NEW_NOTICE_THRESHOLD_DAYS = 7;
+export const NEW_NOTICE_THRESHOLD_DAYS = 7;
+const NOTICE_READ_KEY = 'notice-read';
 
-export const hasNewNotice = (notices: Notice[]): boolean =>
+export const getReadNoticeIds = (): string[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const parsed: unknown = JSON.parse(
+      localStorage.getItem(NOTICE_READ_KEY) ?? '[]'
+    );
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is string => typeof id === 'string');
+  } catch {
+    return [];
+  }
+};
+
+export const markNoticeRead = (id: string): void => {
+  if (typeof window === 'undefined') return;
+  const ids = getReadNoticeIds();
+  if (!ids.includes(id)) {
+    localStorage.setItem(NOTICE_READ_KEY, JSON.stringify([...ids, id]));
+  }
+};
+
+export const hasNewNotice = (
+  notices: Notice[],
+  readIds: string[] = []
+): boolean =>
   notices.some(
     (n) =>
       dayjs().tz().diff(dayjs.tz(n.publishedAt), 'day') <
-      NEW_NOTICE_THRESHOLD_DAYS
+        NEW_NOTICE_THRESHOLD_DAYS && !readIds.includes(n.id)
   );


### PR DESCRIPTION
## 개요

> **한줄 요약**: 공지 상세 페이지 진입 시 UUID 기반으로 읽음 처리하여 벨 dot와 NEW 배지가 사라지도록 개선

기존에는 공지 발행 후 7일 동안 무조건 벨 dot가 표시됐으나, 사용자가 이미 공지를 확인했음에도 계속 알림이 남아있는 문제가 있었습니다. `localStorage`에 읽은 공지 ID를 저장하고, 한번 확인하면 dot와 NEW 배지 모두 사라지도록 변경합니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **읽음 정책** | `noticePolicy.ts` | `getReadNoticeIds`, `markNoticeRead` 추가, `hasNewNotice` readIds 파라미터 확장 |
| **읽음 마커** | `NoticeReadMarker/` | 상세 진입 시 localStorage에 읽음 기록하는 invisible 클라이언트 컴포넌트 |
| **NEW 배지** | `NoticeNewBadge/` | 읽음 여부를 반영하는 클라이언트 배지 컴포넌트 |
| **벨 dot** | `SiteHeader.tsx` | `pathname` 변경마다 readIds 재조회, 모두 읽으면 dot 소거 |
| **공지 목록** | `notice/page.tsx` | 인라인 배지를 `NoticeNewBadge`로 교체, 임계값 상수 공유 |

&nbsp;

## 실행 흐름

\`\`\`mermaid
sequenceDiagram
    participant 사용자
    participant 상세페이지 as /notice/[id]
    participant Marker as NoticeReadMarker
    participant LS as localStorage
    participant Header as SiteHeader

    사용자->>상세페이지: 공지 상세 진입
    상세페이지->>Marker: mount (id 전달)
    Marker->>LS: markNoticeRead(id)
    사용자->>Header: 다른 페이지 이동 (pathname 변경)
    Header->>LS: getReadNoticeIds() 재조회
    Header-->>사용자: 벨 dot 소거
\`\`\`

&nbsp;

## 주요 리뷰 요청사항

- `readIds`는 `pathname` 변경 시마다 localStorage를 재조회합니다. 동일 탭 내 SPA 이동에서는 정상 동작이 확인됐으나, 다중 탭 동시 열람 케이스는 고려하지 않았습니다.

&nbsp;

## 테스트 계획

- [ ] 공지 상세 진입 후 홈 이동 시 벨 dot 소거 확인
- [ ] 공지 목록 페이지 NEW 배지 진입 후 사라짐 확인
- [ ] 새 탭에서 `localStorage` 초기화 후 dot 재노출 확인
- [ ] 7일 이내 공지가 없을 때 dot 미표시 확인
- [ ] 기존 기능(메뉴 조회, 투표 등) 미영향 확인

---

> 🎭 **오늘의 커밋 시**
>
> 한번 읽은 소식은 조용히 사라지고 ☾
> 새 소식엔 노란 점이 반짝이며 말을 건다 ✨
> 기억은 localStorage, 눈은 벨 아이콘에 🔔
> 알았으면 됐어, 이제 꺼줄게 🤫

🤖 Generated with [Claude Code](https://claude.com/claude-code)