### PR TITLE
refactor: [메뉴판] 모바일 탭 UI·오늘 버튼·kcal 재배치·자정 갱신

### DIFF
--- a/src/components/@shared/layout/PageLayout/PageLayout.styles.ts
+++ b/src/components/@shared/layout/PageLayout/PageLayout.styles.ts
@@ -1,13 +1,13 @@
 export const pageMainClass = 'mx-auto w-[min(880px,calc(100%-40px))] flex-1';
 
 export const pageHeaderClass =
-  'flex flex-col justify-start pt-12 pb-6 min-h-[168px] max-[640px]:pt-6 max-[640px]:pb-3 max-[640px]:min-h-0';
+  'flex flex-col justify-start pt-12 pb-6 min-h-[168px] max-[640px]:pt-4 max-[640px]:pb-2 max-[640px]:min-h-0';
 
 export const pageEyebrowClass =
   'text-muted text-[11.5px] font-semibold tracking-[0.06em] uppercase';
 
 export const pageTitleClass =
-  'text-ink text-[26px] font-extrabold tracking-[-0.02em] max-[560px]:text-[20px]';
+  'text-ink text-[26px] font-extrabold tracking-[-0.02em] max-[640px]:text-[18px]';
 
 export const pageDescClass = 'text-muted mt-2 text-[15px] max-[640px]:hidden';
 

--- a/src/components/@shared/layout/PageLayout/PageLayout.styles.ts
+++ b/src/components/@shared/layout/PageLayout/PageLayout.styles.ts
@@ -1,14 +1,14 @@
 export const pageMainClass = 'mx-auto w-[min(880px,calc(100%-40px))] flex-1';
 
 export const pageHeaderClass =
-  'flex min-h-[168px] flex-col justify-start pt-12 pb-6';
+  'flex flex-col justify-start pt-12 pb-6 min-h-[168px] max-[640px]:pt-6 max-[640px]:pb-3 max-[640px]:min-h-0';
 
 export const pageEyebrowClass =
   'text-muted text-[11.5px] font-semibold tracking-[0.06em] uppercase';
 
 export const pageTitleClass =
-  'text-ink mt-3 text-[26px] font-extrabold tracking-[-0.02em] max-[560px]:text-[20px]';
+  'text-ink text-[26px] font-extrabold tracking-[-0.02em] max-[560px]:text-[20px]';
 
-export const pageDescClass = 'text-muted mt-2 text-[15px]';
+export const pageDescClass = 'text-muted mt-2 text-[15px] max-[640px]:hidden';
 
 export const pageContentClass = 'pb-10';

--- a/src/components/@shared/layout/PageLayout/PageLayout.tsx
+++ b/src/components/@shared/layout/PageLayout/PageLayout.tsx
@@ -13,6 +13,7 @@ interface PageLayoutProps {
   eyebrow: ReactNode;
   title: ReactNode;
   description?: ReactNode;
+  headerAction?: ReactNode;
   children: ReactNode;
 }
 
@@ -20,12 +21,16 @@ const PageLayout = ({
   eyebrow,
   title,
   description,
+  headerAction,
   children,
 }: PageLayoutProps) => (
   <main className={pageMainClass}>
     <section className={pageHeaderClass}>
       <p className={pageEyebrowClass}>{eyebrow}</p>
-      <h1 className={pageTitleClass}>{title}</h1>
+      <div className="mt-3 flex items-center justify-between">
+        <h1 className={pageTitleClass}>{title}</h1>
+        {headerAction}
+      </div>
       {description && <p className={pageDescClass}>{description}</p>}
     </section>
     <div className={pageContentClass}>{children}</div>

--- a/src/components/home/HeroStatus/HeroStatus.tsx
+++ b/src/components/home/HeroStatus/HeroStatus.tsx
@@ -53,7 +53,7 @@ const HeroStatus = ({ menus }: { menus: MenuType[] }) => {
       <Icon
         size={26}
         strokeWidth={2}
-        className="shrink-0"
+        className="shrink-0 max-[640px]:size-[18px]"
         style={{
           animation: isOperating
             ? 'softPulse 2.4s ease-in-out infinite'

--- a/src/components/home/HeroTodayButton/HeroTodayButton.styles.ts
+++ b/src/components/home/HeroTodayButton/HeroTodayButton.styles.ts
@@ -1,0 +1,2 @@
+export const todayBtnClass =
+  'cursor-pointer bg-accent-soft px-2 py-0.5 text-[10px] font-bold text-accent-text transition-colors hover:bg-accent hover:text-ink focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ink';

--- a/src/components/home/HeroTodayButton/HeroTodayButton.tsx
+++ b/src/components/home/HeroTodayButton/HeroTodayButton.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { sendGAEvent } from '@next/third-parties/google';
+
+import { useHasMounted } from '@/hooks/useHasMounted';
+import { useDateStore } from '@/store/useDateStore';
+
+import { todayBtnClass } from './HeroTodayButton.styles';
+
+const HeroTodayButton = () => {
+  const { today, currentWeek, goToToday } = useDateStore();
+  const mounted = useHasMounted();
+
+  const isCurrentWeek =
+    mounted && currentWeek.some((d) => d.isSame(today, 'day'));
+
+  if (!mounted || isCurrentWeek) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        sendGAEvent('event', 'week_navigate', { direction: 'today' });
+        goToToday();
+      }}
+      aria-label="오늘 날짜로 이동"
+      className={todayBtnClass}
+    >
+      오늘
+    </button>
+  );
+};
+
+export default HeroTodayButton;

--- a/src/components/home/HeroTodayButton/index.ts
+++ b/src/components/home/HeroTodayButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HeroTodayButton';

--- a/src/components/menu/MenuBoard/MenuBoard.styles.ts
+++ b/src/components/menu/MenuBoard/MenuBoard.styles.ts
@@ -1,10 +1,15 @@
 export const sectionClass =
   'bg-surface flex flex-col shadow-[var(--shadow-card)]';
 
-export const menuHeadingTitleClass =
-  'text-ink text-[14px] font-extrabold tracking-wide';
+export const menuBodyClass =
+  'grid grid-cols-1 min-h-[280px] min-[640px]:grid-cols-3 min-[640px]:divide-x min-[640px]:divide-line';
 
-export const menuSubheadingClass =
-  'text-ink-2 flex items-center gap-1 text-[11px] font-medium';
+export const courseTabBarClass = 'flex min-[640px]:hidden border-b border-line';
 
-export const menuBodyClass = 'flex flex-col min-h-[180px] overflow-hidden';
+export const courseTabClass = (active: boolean) =>
+  active
+    ? 'flex-1 py-2.5 text-[13px] font-bold text-ink border-b-2 border-accent -mb-px text-center transition-colors'
+    : 'flex-1 py-2.5 text-[13px] font-semibold text-muted text-center transition-colors hover:text-ink';
+
+export const menuShareBtnClass =
+  'fixed bottom-6 right-6 z-20 flex size-11 cursor-pointer items-center justify-center bg-surface text-muted shadow-[var(--shadow-card)] transition-colors hover:text-ink focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ink';

--- a/src/components/menu/MenuBoard/MenuBoard.tsx
+++ b/src/components/menu/MenuBoard/MenuBoard.tsx
@@ -1,28 +1,29 @@
 'use client';
 
-import { Clock } from 'lucide-react';
-import { useLayoutEffect, useMemo, useRef } from 'react';
+import { sendGAEvent } from '@next/third-parties/google';
+import { Share2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
 
-import { CAFETERIA_LABEL } from '@/constants/cafeteria';
-import { MENU_CATEGORIES } from '@/constants/menu';
+import { MENU_CATEGORIES, MenuCategoryLabel } from '@/constants/menu';
 import { useDateUrl } from '@/hooks/useDateUrl';
 import { useHasMounted } from '@/hooks/useHasMounted';
 import { usePick } from '@/hooks/usePick';
 import { useVotes } from '@/hooks/useVote';
 import dayjs from '@/lib/dayjs';
+import { shareMenuUrl } from '@/lib/share';
 import { useDateStore } from '@/store/useDateStore';
 import { formatYYYYMMDD } from '@/utils/date';
 import { isAfterClose, isFutureMenuPending } from '@/utils/menuPolicy';
-
-import HeroTodayButton from '@/components/home/HeroTodayButton';
 
 import MenuBoardCourseRow from './_MenuBoardCourseRow/MenuBoardCourseRow';
 import MenuBoardDayBar from './_MenuBoardDayBar/MenuBoardDayBar';
 import MenuBoardEmpty from './_MenuBoardEmpty/MenuBoardEmpty';
 import {
+  courseTabBarClass,
+  courseTabClass,
   menuBodyClass,
-  menuHeadingTitleClass,
-  menuSubheadingClass,
+  menuShareBtnClass,
   sectionClass,
 } from './MenuBoard.styles';
 import { MenuBoardProps } from './MenuBoard.types';
@@ -31,6 +32,7 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
   useDateUrl();
   const { today, selectedDate } = useDateStore();
   const mounted = useHasMounted();
+  const [selectedTab, setSelectedTab] = useState(0);
   const dateStr = formatYYYYMMDD(selectedDate);
   const hasMenus = useMemo(
     () => menus.some((m) => m.date === dateStr && m.items.length > 0),
@@ -61,77 +63,87 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
     ).filter((m): m is NonNullable<typeof m> => Boolean(m));
   }, [menus, selectedDate]);
 
+  useEffect(() => setSelectedTab(0), [dateStr]);
+
   const emptyVariant = isFutureMenuPending(selectedDate, now)
     ? 'comingUp'
     : 'closed';
 
-  const menuBodyRef = useRef<HTMLDivElement>(null);
-  const prevHeightRef = useRef(0);
-
-  useLayoutEffect(() => {
-    const el = menuBodyRef.current;
-    if (!el) return;
-    const next = el.scrollHeight;
-    const prev = prevHeightRef.current;
-    prevHeightRef.current = next;
-    if (!prev || prev === next) return;
-    const a = el.animate([{ height: `${prev}px` }, { height: `${next}px` }], {
-      duration: 280,
-      easing: 'ease-in-out',
-    });
-    return () => a.cancel();
-  }, [dateStr]);
+  const handleShare = async () => {
+    sendGAEvent('event', 'share_menu', { date: dateStr });
+    const result = await shareMenuUrl(dateStr);
+    if (result === 'copied') toast.success('링크 복사됨');
+    if (result === 'error') toast.error('링크 복사 실패');
+  };
 
   return (
     <section className={sectionClass}>
-      <div className="flex items-center justify-between px-6 py-4">
-        <div className="flex items-center gap-2">
-          <h2 className={menuHeadingTitleClass}>메가존 구내식당</h2>
-          <p className={menuSubheadingClass}>
-            <Clock
-              size={9}
-              strokeWidth={2.5}
-              className="text-muted"
-              aria-hidden
-            />
-            <span>{CAFETERIA_LABEL}</span>
-          </p>
-        </div>
-        <HeroTodayButton />
-      </div>
+      <button
+        type="button"
+        onClick={handleShare}
+        aria-label="메뉴 링크 공유"
+        className={menuShareBtnClass}
+      >
+        <Share2 size={15} strokeWidth={2} aria-hidden />
+      </button>
       <MenuBoardDayBar />
-      <div ref={menuBodyRef} className={menuBodyClass}>
+      {dayMenus.length > 1 && (
+        <div className={courseTabBarClass}>
+          {dayMenus.map((menu, i) => (
+            <button
+              key={menu.category}
+              type="button"
+              onClick={() => setSelectedTab(i)}
+              aria-pressed={selectedTab === i}
+              className={courseTabClass(selectedTab === i)}
+            >
+              {MenuCategoryLabel[menu.category].ko}
+            </button>
+          ))}
+        </div>
+      )}
+      <div className={menuBodyClass}>
         {dayMenus.length > 0 ? (
-          dayMenus.map((menu) => {
+          dayMenus.map((menu, i) => {
             const menuKey = `${menu.date}_${menu.category}`;
             return (
-              <MenuBoardCourseRow
+              <div
                 key={menu.category}
-                menu={menu}
-                vote={{
-                  show: showVote && !isLoading,
-                  result: voteMap[menuKey],
-                  onVote: (type: 'up' | 'down') => submitVote(menuKey, type),
-                  isSubmitting,
-                }}
-                pick={{
-                  show: showPick && !isLoadingPick,
-                  count: counts[menu.category],
-                  isPicked: myPick === menu.category,
-                  hasAnyPick: myPick !== null,
-                  onPick: () => submitPick(menu.category),
-                  isSubmitting: isSubmittingPick,
-                }}
-              />
+                className={
+                  i !== selectedTab
+                    ? 'hidden h-full min-[640px]:block'
+                    : 'h-full'
+                }
+              >
+                <MenuBoardCourseRow
+                  menu={menu}
+                  vote={{
+                    show: showVote && !isLoading,
+                    result: voteMap[menuKey],
+                    onVote: (type: 'up' | 'down') => submitVote(menuKey, type),
+                    isSubmitting,
+                  }}
+                  pick={{
+                    show: showPick && !isLoadingPick,
+                    count: counts[menu.category],
+                    isPicked: myPick === menu.category,
+                    hasAnyPick: myPick !== null,
+                    onPick: () => submitPick(menu.category),
+                    isSubmitting: isSubmittingPick,
+                  }}
+                />
+              </div>
             );
           })
         ) : (
-          <MenuBoardEmpty
-            variant={emptyVariant}
-            date={dateStr}
-            isToday={isToday}
-            isPast={isPast}
-          />
+          <div className="col-span-full">
+            <MenuBoardEmpty
+              variant={emptyVariant}
+              date={dateStr}
+              isToday={isToday}
+              isPast={isPast}
+            />
+          </div>
         )}
       </div>
     </section>

--- a/src/components/menu/MenuBoard/MenuBoard.tsx
+++ b/src/components/menu/MenuBoard/MenuBoard.tsx
@@ -14,6 +14,8 @@ import { useDateStore } from '@/store/useDateStore';
 import { formatYYYYMMDD } from '@/utils/date';
 import { isAfterClose, isFutureMenuPending } from '@/utils/menuPolicy';
 
+import HeroTodayButton from '@/components/home/HeroTodayButton';
+
 import MenuBoardCourseRow from './_MenuBoardCourseRow/MenuBoardCourseRow';
 import MenuBoardDayBar from './_MenuBoardDayBar/MenuBoardDayBar';
 import MenuBoardEmpty from './_MenuBoardEmpty/MenuBoardEmpty';
@@ -82,17 +84,20 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
 
   return (
     <section className={sectionClass}>
-      <div className="flex items-center gap-2 px-6 py-4">
-        <h2 className={menuHeadingTitleClass}>메가존 구내식당</h2>
-        <p className={menuSubheadingClass}>
-          <Clock
-            size={9}
-            strokeWidth={2.5}
-            className="text-muted"
-            aria-hidden
-          />
-          <span>{CAFETERIA_LABEL}</span>
-        </p>
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex items-center gap-2">
+          <h2 className={menuHeadingTitleClass}>메가존 구내식당</h2>
+          <p className={menuSubheadingClass}>
+            <Clock
+              size={9}
+              strokeWidth={2.5}
+              className="text-muted"
+              aria-hidden
+            />
+            <span>{CAFETERIA_LABEL}</span>
+          </p>
+        </div>
+        <HeroTodayButton />
       </div>
       <MenuBoardDayBar />
       <div ref={menuBodyRef} className={menuBodyClass}>

--- a/src/components/menu/MenuBoard/MenuBoard.tsx
+++ b/src/components/menu/MenuBoard/MenuBoard.tsx
@@ -63,6 +63,8 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
     ).filter((m): m is NonNullable<typeof m> => Boolean(m));
   }, [menus, selectedDate]);
 
+  const safeTab =
+    dayMenus.length > 0 ? Math.min(selectedTab, dayMenus.length - 1) : 0;
   useEffect(() => setSelectedTab(0), [dateStr]);
 
   const emptyVariant = isFutureMenuPending(selectedDate, now)
@@ -94,8 +96,8 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
               key={menu.category}
               type="button"
               onClick={() => setSelectedTab(i)}
-              aria-pressed={selectedTab === i}
-              className={courseTabClass(selectedTab === i)}
+              aria-pressed={safeTab === i}
+              className={courseTabClass(safeTab === i)}
             >
               {MenuCategoryLabel[menu.category].ko}
             </button>
@@ -110,9 +112,7 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
               <div
                 key={menu.category}
                 className={
-                  i !== selectedTab
-                    ? 'hidden h-full min-[640px]:block'
-                    : 'h-full'
+                  i !== safeTab ? 'hidden h-full min-[640px]:block' : 'h-full'
                 }
               >
                 <MenuBoardCourseRow

--- a/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.styles.ts
@@ -20,13 +20,13 @@ export const courseLabelClass =
   'text-accent-text text-[13px] font-extrabold tracking-wider';
 
 export const kcalClass =
-  'mt-auto flex justify-between border-t border-dashed border-line pt-3 text-accent-text text-[11px] font-semibold';
+  'mt-6 flex justify-between border-t border-dashed border-line pt-3 text-accent-text text-[11px] font-semibold';
 
 export const voteGroupClass =
   'ml-auto flex gap-1 animate-[fadeIn_0.3s_ease_both]';
 
 export const itemsTextClass =
-  'mt-2 flex flex-col gap-y-1 text-ink text-[14.5px] leading-relaxed font-semibold';
+  'mt-2 flex flex-1 flex-col gap-y-1 text-ink text-[14.5px] leading-relaxed font-semibold';
 
 export const itemNameClass = 'flex items-baseline justify-between gap-2';
 
@@ -44,6 +44,9 @@ export const pickButtonClass = (isPicked: boolean, hasAnyPick: boolean) =>
         ? 'border-line text-muted opacity-60 hover:border-accent/50 hover:text-ink hover:opacity-100'
         : 'border-line text-muted hover:border-accent/50 hover:text-ink'
   );
+
+export const pickCountClass = (hasCount: boolean) =>
+  hasCount ? 'font-bold text-accent-text' : '';
 
 export const upVoteButtonClass = (myVote: VoteType | null) =>
   cn(

--- a/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.styles.ts
@@ -20,7 +20,7 @@ export const courseLabelClass =
   'text-accent-text text-[13px] font-extrabold tracking-wider';
 
 export const kcalClass =
-  'mt-6 flex justify-between border-t border-dashed border-line pt-3 text-accent-text text-[11px] font-semibold';
+  'mt-3 flex justify-between border-t border-dashed border-line pt-3 text-accent-text text-[11px] font-semibold';
 
 export const voteGroupClass =
   'ml-auto flex gap-1 animate-[fadeIn_0.3s_ease_both]';

--- a/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.styles.ts
@@ -12,27 +12,26 @@ export const tooltipClass = (isOpen: boolean) =>
       : 'invisible opacity-0 group-hover:visible group-hover:opacity-100'
   );
 
-export const courseRowClass = 'px-5 py-6';
+export const courseRowClass = 'flex h-full flex-col px-5 py-6';
 
 export const courseRowHeaderClass = 'mb-1.5 flex items-end gap-2';
 
 export const courseLabelClass =
   'text-accent-text text-[13px] font-extrabold tracking-wider';
 
-export const kcalClass = 'text-muted text-[11px] font-semibold';
+export const kcalClass =
+  'mt-auto flex justify-between border-t border-dashed border-line pt-3 text-accent-text text-[11px] font-semibold';
 
 export const voteGroupClass =
   'ml-auto flex gap-1 animate-[fadeIn_0.3s_ease_both]';
 
 export const itemsTextClass =
-  'mt-2 flex flex-wrap gap-x-0.5 text-ink text-[14.5px] leading-relaxed font-semibold';
+  'mt-2 flex flex-col gap-y-1 text-ink text-[14.5px] leading-relaxed font-semibold';
 
-export const itemNameClass = 'break-words';
+export const itemNameClass = 'flex items-baseline justify-between gap-2';
 
 export const itemKcalClass =
-  'text-muted ml-0.5 text-[10px] font-semibold not-italic';
-
-export const itemSeparatorClass = 'text-line mx-1.5 select-none';
+  'text-muted shrink-0 text-[10px] font-semibold not-italic';
 
 export const tabularNumsClass = 'tabular-nums';
 

--- a/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.tsx
@@ -17,6 +17,7 @@ import {
   itemsTextClass,
   kcalClass,
   pickButtonClass,
+  pickCountClass,
   tabularNumsClass,
   upVoteButtonClass,
   upVoteIconClass,
@@ -89,7 +90,10 @@ const MenuBoardCourseRow = ({ menu, vote, pick }: MenuBoardCourseRowProps) => {
             )}
           >
             <Users size={10} strokeWidth={2.5} />
-            {pick.count ?? 0}명이 선택했어요
+            <span className={pickCountClass((pick.count ?? 0) >= 1)}>
+              {pick.count ?? 0}
+            </span>
+            명이 선택했어요
           </button>
         )}
         {vote?.show && (

--- a/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.tsx
@@ -158,7 +158,7 @@ const MenuBoardCourseRow = ({ menu, vote, pick }: MenuBoardCourseRowProps) => {
         )}
       </div>
       <p className={itemsTextClass}>
-        {menu.items.map((item, i) => (
+        {menu.items.map((item) => (
           <span key={item.name} className={itemNameClass}>
             <span className="break-words">{item.name}</span>
             {item.kcal > 0 && (

--- a/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.tsx
@@ -14,7 +14,6 @@ import {
   downVoteIconClass,
   itemKcalClass,
   itemNameClass,
-  itemSeparatorClass,
   itemsTextClass,
   kcalClass,
   pickButtonClass,
@@ -77,7 +76,6 @@ const MenuBoardCourseRow = ({ menu, vote, pick }: MenuBoardCourseRowProps) => {
         >
           {MenuCategoryLabel[menu.category].ko}
         </span>
-        {total > 0 && <span className={kcalClass}>{total} kcal</span>}
         {pick?.show && (
           <button
             type="button"
@@ -162,16 +160,19 @@ const MenuBoardCourseRow = ({ menu, vote, pick }: MenuBoardCourseRowProps) => {
       <p className={itemsTextClass}>
         {menu.items.map((item, i) => (
           <span key={item.name} className={itemNameClass}>
-            {item.name}
+            <span className="break-words">{item.name}</span>
             {item.kcal > 0 && (
               <i className={itemKcalClass}>{`${item.kcal}kcal`}</i>
-            )}
-            {i < menu.items.length - 1 && (
-              <span className={itemSeparatorClass}>·</span>
             )}
           </span>
         ))}
       </p>
+      {total > 0 && (
+        <p className={kcalClass}>
+          <span>합계</span>
+          <span>{total} kcal</span>
+        </p>
+      )}
     </div>
   );
 };

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -22,6 +22,9 @@ export const navArrowClass =
 export const navTooltipClass =
   'pointer-events-none absolute top-full left-1/2 z-10 mt-1.5 -translate-x-1/2 whitespace-nowrap bg-ink px-2 py-1 text-[10px] font-medium text-cream invisible opacity-0 transition-opacity group-hover:visible group-hover:opacity-100';
 
+export const todayBtnClass =
+  'cursor-pointer bg-accent-soft px-2 py-0.5 text-[10px] font-bold text-accent-text transition-colors hover:bg-accent hover:text-ink focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ink';
+
 export const chipAreaClass = 'px-4 pb-2.5';
 
 export const chipRowClass = 'relative flex gap-1.5 overflow-hidden';

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -2,22 +2,22 @@ import { cn } from '@/utils/cn';
 
 export const dayBarContainerClass = 'bg-surface flex flex-col';
 
-export const weekLabelClass = 'flex items-center gap-0.5 px-4 pt-1.5 pb-0.5';
+export const weekLabelClass = 'flex items-center px-2 pt-2 pb-1';
 
 export const shareBtnClass =
   'flex min-h-11 min-w-11 cursor-pointer items-center justify-center text-muted transition-colors duration-100 hover:text-ink focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ink';
 
 export const weekRangeClass =
-  'flex-1 text-center text-[11px] font-semibold tabular-nums text-muted';
+  'flex-1 text-center text-[15px] font-bold tabular-nums text-ink';
 
 export const navButtonClass = (visible: boolean) =>
   cn(
-    'group relative flex cursor-pointer items-center justify-center px-1 py-2 text-muted transition-opacity duration-100 hover:text-ink',
+    'group relative flex cursor-pointer items-center justify-center px-2 py-2.5 text-muted transition-opacity duration-100 hover:text-ink',
     !visible && 'invisible pointer-events-none'
   );
 
 export const navArrowClass =
-  'text-[14px] leading-none font-light transition-transform group-active:scale-75';
+  'text-[20px] leading-none font-light transition-transform group-active:scale-75';
 
 export const navTooltipClass =
   'pointer-events-none absolute top-full left-1/2 z-10 mt-1.5 -translate-x-1/2 whitespace-nowrap bg-ink px-2 py-1 text-[10px] font-medium text-cream invisible opacity-0 transition-opacity group-hover:visible group-hover:opacity-100';

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -41,8 +41,7 @@ export const chipBg = (isSelected: boolean): string => {
 };
 
 const dowColor = (dow: number): string | null => {
-  if (dow === 0) return 'text-rose-400/70';
-  if (dow === 6) return 'text-sky-400/70';
+  if (dow === 0 || dow === 6) return 'text-muted';
   return null;
 };
 

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -41,7 +41,8 @@ export const chipBg = (isSelected: boolean): string => {
 };
 
 const dowColor = (dow: number): string | null => {
-  if (dow === 0 || dow === 6) return 'text-muted';
+  if (dow === 0) return 'text-rose-400/70';
+  if (dow === 6) return 'text-sky-400/70';
   return null;
 };
 

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -47,7 +47,7 @@ const MenuBoardDayBar = () => {
     ? ''
     : isCurrentWeek
       ? '이번주'
-      : currentWeek[0].isBefore(today, 'week')
+      : currentWeek[6].isBefore(today, 'day')
         ? '지난주'
         : '다음주';
   const prevLabel = isCurrentWeek ? '지난주' : '이번주';

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -1,14 +1,10 @@
 'use client';
 
 import { sendGAEvent } from '@next/third-parties/google';
-import { Share2 } from 'lucide-react';
 import { useEffect } from 'react';
-import toast from 'react-hot-toast';
 
 import { useHasMounted } from '@/hooks/useHasMounted';
-import { shareMenuUrl } from '@/lib/share';
 import { useDateStore } from '@/store/useDateStore';
-import { formatYYYYMMDD } from '@/utils/date';
 
 import {
   chipAreaClass,
@@ -18,7 +14,6 @@ import {
   navArrowClass,
   navButtonClass,
   navTooltipClass,
-  shareBtnClass,
   weekLabelClass,
   weekRangeClass,
 } from './MenuBoardDayBar.styles';
@@ -43,19 +38,18 @@ const MenuBoardDayBar = () => {
     return () => clearInterval(id);
   }, [refreshToday]);
 
-  const handleShare = async () => {
-    const dateStr = formatYYYYMMDD(selectedDate);
-    sendGAEvent('event', 'share_menu', { date: dateStr });
-    const result = await shareMenuUrl(dateStr);
-    if (result === 'copied') toast.success('링크 복사됨');
-    if (result === 'error') toast.error('링크 복사 실패');
-  };
-
   const canGoPrev = !mounted || currentWeek[0].isAfter(minDate, 'day');
   const canGoNext = !mounted || currentWeek[6].isBefore(maxDate, 'day');
 
   const isCurrentWeek =
     mounted && currentWeek.some((d) => d.isSame(today, 'day'));
+  const weekLabel = !mounted
+    ? ''
+    : isCurrentWeek
+      ? '이번주'
+      : currentWeek[0].isBefore(today, 'week')
+        ? '지난주'
+        : '다음주';
   const prevLabel = isCurrentWeek ? '지난주' : '이번주';
   const nextLabel = isCurrentWeek ? '다음주' : '이번주';
 
@@ -75,9 +69,7 @@ const MenuBoardDayBar = () => {
           <span className={navTooltipClass}>{prevLabel}</span>
         </button>
         <span suppressHydrationWarning className={weekRangeClass}>
-          {mounted
-            ? `${currentWeek[0].format('M월 D일')} - ${currentWeek[6].format('M월 D일')}`
-            : ''}
+          {weekLabel}
         </span>
         <button
           type="button"
@@ -90,14 +82,6 @@ const MenuBoardDayBar = () => {
         >
           <span className={navArrowClass}>›</span>
           <span className={navTooltipClass}>{nextLabel}</span>
-        </button>
-        <button
-          type="button"
-          onClick={handleShare}
-          aria-label="메뉴 링크 공유"
-          className={shareBtnClass}
-        >
-          <Share2 size={13} strokeWidth={2} aria-hidden />
         </button>
       </div>
       <div className={chipAreaClass}>

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -19,7 +19,6 @@ import {
   navButtonClass,
   navTooltipClass,
   shareBtnClass,
-  todayBtnClass,
   weekLabelClass,
   weekRangeClass,
 } from './MenuBoardDayBar.styles';
@@ -35,7 +34,6 @@ const MenuBoardDayBar = () => {
     setSelectedDate,
     goToPrevWeek,
     goToNextWeek,
-    goToToday,
     refreshToday,
   } = useDateStore();
   const mounted = useHasMounted();
@@ -101,19 +99,6 @@ const MenuBoardDayBar = () => {
         >
           <Share2 size={13} strokeWidth={2} aria-hidden />
         </button>
-        {mounted && !isCurrentWeek && (
-          <button
-            type="button"
-            onClick={() => {
-              sendGAEvent('event', 'week_navigate', { direction: 'today' });
-              goToToday();
-            }}
-            aria-label="오늘 날짜로 이동"
-            className={todayBtnClass}
-          >
-            오늘
-          </button>
-        )}
       </div>
       <div className={chipAreaClass}>
         <div

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -2,6 +2,7 @@
 
 import { sendGAEvent } from '@next/third-parties/google';
 import { Share2 } from 'lucide-react';
+import { useEffect } from 'react';
 import toast from 'react-hot-toast';
 
 import { useHasMounted } from '@/hooks/useHasMounted';
@@ -18,6 +19,7 @@ import {
   navButtonClass,
   navTooltipClass,
   shareBtnClass,
+  todayBtnClass,
   weekLabelClass,
   weekRangeClass,
 } from './MenuBoardDayBar.styles';
@@ -33,8 +35,15 @@ const MenuBoardDayBar = () => {
     setSelectedDate,
     goToPrevWeek,
     goToNextWeek,
+    goToToday,
+    refreshToday,
   } = useDateStore();
   const mounted = useHasMounted();
+
+  useEffect(() => {
+    const id = setInterval(refreshToday, 60_000);
+    return () => clearInterval(id);
+  }, [refreshToday]);
 
   const handleShare = async () => {
     const dateStr = formatYYYYMMDD(selectedDate);
@@ -92,6 +101,19 @@ const MenuBoardDayBar = () => {
         >
           <Share2 size={13} strokeWidth={2} aria-hidden />
         </button>
+        {mounted && !isCurrentWeek && (
+          <button
+            type="button"
+            onClick={() => {
+              sendGAEvent('event', 'week_navigate', { direction: 'today' });
+              goToToday();
+            }}
+            aria-label="오늘 날짜로 이동"
+            className={todayBtnClass}
+          >
+            오늘
+          </button>
+        )}
       </div>
       <div className={chipAreaClass}>
         <div

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayChip.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayChip.styles.ts
@@ -5,7 +5,8 @@ import { chipBg, labelClass, dateClass } from './MenuBoardDayBar.styles';
 export const chipButtonClass = (
   isSelected: boolean,
   isToday: boolean,
-  justSelected: boolean
+  justSelected: boolean,
+  isWeekend: boolean
 ) =>
   cn(
     'relative flex min-h-[44px] flex-1 cursor-pointer flex-col items-center justify-center gap-0.5 transition-colors duration-150 active:opacity-70',
@@ -13,7 +14,8 @@ export const chipButtonClass = (
     isToday &&
       !isSelected &&
       "after:absolute after:bottom-1.5 after:left-1/2 after:size-1 after:-translate-x-1/2 after:bg-accent after:content-['']",
-    justSelected && 'animate-[chipPop_0.22s_ease-out]'
+    justSelected && 'animate-[chipPop_0.22s_ease-out]',
+    isWeekend && !isSelected && !isToday && 'opacity-50'
   );
 
 export const chipDowClass = (

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayChip.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayChip.tsx
@@ -19,6 +19,7 @@ const MenuBoardDayChip = ({
 }: MenuBoardDayChipProps) => {
   const isToday = mounted && day.isSame(today, 'day');
   const isSelected = mounted && day.isSame(selectedDate, 'day');
+  const isWeekend = day.day() === 0 || day.day() === 6;
   const [justSelected, setJustSelected] = useState(false);
 
   useEffect(() => {
@@ -33,7 +34,7 @@ const MenuBoardDayChip = ({
       type="button"
       onClick={() => onSelect(day)}
       aria-pressed={isSelected}
-      className={chipButtonClass(isSelected, isToday, justSelected)}
+      className={chipButtonClass(isSelected, isToday, justSelected, isWeekend)}
     >
       <span
         suppressHydrationWarning

--- a/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
@@ -36,7 +36,7 @@ const MenuBoardEmpty = ({
   })();
 
   return (
-    <div className="relative flex flex-1 flex-col items-center justify-center overflow-hidden px-6 py-12 text-center">
+    <div className="relative flex h-full flex-col items-center justify-center overflow-hidden px-6 py-12 text-center">
       {variant === 'closed' && (
         <div className="pointer-events-none absolute inset-0" aria-hidden>
           <span

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -15,7 +15,7 @@ export const shareMenuUrl = async (dateStr: string): Promise<ShareResult> => {
   }
 
   try {
-    await navigator.clipboard.writeText(url);
+  await navigator.clipboard.writeText(url);
     return 'copied';
   } catch {
     return 'error';

--- a/src/store/useDateStore.ts
+++ b/src/store/useDateStore.ts
@@ -13,6 +13,8 @@ interface DateStore {
   initFromDate: (date: dayjs.Dayjs) => void;
   goToPrevWeek: () => void;
   goToNextWeek: () => void;
+  goToToday: () => void;
+  refreshToday: () => void;
 }
 
 export const useDateStore = create<DateStore>((set, get) => {
@@ -44,6 +46,27 @@ export const useDateStore = create<DateStore>((set, get) => {
       const nextWeekStart = currentWeek[6].add(1, 'day');
       if (nextWeekStart.isAfter(maxDate, 'day')) return;
       set({ currentWeek: getWeekDays(nextWeekStart) });
+    },
+
+    goToToday: () => {
+      const freshToday = dayjs().tz();
+      set({
+        today: freshToday,
+        minDate: getWeekDays(freshToday.subtract(1, 'week'))[0],
+        maxDate: getWeekDays(freshToday.add(1, 'week'))[6],
+        selectedDate: freshToday,
+        currentWeek: getWeekDays(freshToday),
+      });
+    },
+
+    refreshToday: () => {
+      const freshToday = dayjs().tz();
+      if (freshToday.isSame(get().today, 'day')) return;
+      set({
+        today: freshToday,
+        minDate: getWeekDays(freshToday.subtract(1, 'week'))[0],
+        maxDate: getWeekDays(freshToday.add(1, 'week'))[6],
+      });
     },
   };
 });

--- a/src/store/useDateStore.ts
+++ b/src/store/useDateStore.ts
@@ -35,17 +35,27 @@ export const useDateStore = create<DateStore>((set, get) => {
       set({ selectedDate: date, currentWeek: getWeekDays(date) }),
 
     goToPrevWeek: () => {
-      const { currentWeek, minDate } = get();
+      const { currentWeek, minDate, today } = get();
       const prevWeekStart = currentWeek[0].subtract(7, 'day');
       if (prevWeekStart.isBefore(minDate, 'day')) return;
-      set({ currentWeek: getWeekDays(prevWeekStart) });
+      const newWeek = getWeekDays(prevWeekStart);
+      const hasToday = newWeek.some((d) => d.isSame(today, 'day'));
+      set({
+        currentWeek: newWeek,
+        selectedDate: hasToday ? today : newWeek[0],
+      });
     },
 
     goToNextWeek: () => {
-      const { currentWeek, maxDate } = get();
+      const { currentWeek, maxDate, today } = get();
       const nextWeekStart = currentWeek[6].add(1, 'day');
       if (nextWeekStart.isAfter(maxDate, 'day')) return;
-      set({ currentWeek: getWeekDays(nextWeekStart) });
+      const newWeek = getWeekDays(nextWeekStart);
+      const hasToday = newWeek.some((d) => d.isSame(today, 'day'));
+      set({
+        currentWeek: newWeek,
+        selectedDate: hasToday ? today : newWeek[0],
+      });
     },
 
     goToToday: () => {


### PR DESCRIPTION
Closes #67

## 개요

> **한줄 요약**: 메뉴판 UI를 모바일 우선으로 재편 — 코스 탭, 오늘 바로가기, kcal 재배치, 자정 자동 갱신

화면이 좁은 모바일에서 세 코스를 가로로 나란히 표시하기 어려운 문제를 해결하기 위해 탭 UI를 도입했습니다. 날짜를 벗어난 주에서 오늘로 빠르게 돌아올 수 있는 버튼을 추가하고, DayBar가 자정마다 today를 갱신해 장시간 오픈한 탭에서도 날짜 기준이 올바르게 유지되도록 했습니다. 공유 버튼은 DayBar에서 분리해 MenuBoard 우하단 FAB으로 이전했습니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **Store / 날짜 상태** | `useDateStore.ts` | `goToToday`·`refreshToday` 액션 추가, 주간 이동 시 `selectedDate` 자동 설정 |
| **오늘 버튼** | `HeroTodayButton.tsx`, `HeroTodayButton.styles.ts`, `index.ts` | 타 주 이동 시 헤딩 우측에 오늘 버튼 표시 |
| **레이아웃** | `PageLayout.tsx`, `PageLayout.styles.ts` | 모바일 헤더 패딩·타이포 축소, `headerAction` slot 추가 |
| **메뉴판 탭 + 공유** | `MenuBoard.tsx`, `MenuBoard.styles.ts` | 모바일 코스 탭 UI 추가, 공유 버튼을 FAB으로 이전 |
| **DayBar** | `MenuBoardDayBar.tsx`, `MenuBoardDayBar.styles.ts` | 60초 자정 갱신 인터벌, 주간 레이블 이번주/지난주/다음주, 주말 칩 약화 |
| **코스 행** | `MenuBoardCourseRow.tsx`, `MenuBoardCourseRow.styles.ts`, `MenuBoardDayChip.tsx` | kcal 하단 합계 재배치, 아이템별 우정렬 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 유저
    participant 오늘버튼
    participant 스토어
    participant DayBar
    participant MenuBoard

    유저->>오늘버튼: "오늘" 클릭 (타 주 이동 시 표시)
    오늘버튼->>스토어: goToToday()
    스토어->>스토어: today·minDate·maxDate·selectedDate·currentWeek 동기화
    스토어-->>DayBar: 상태 업데이트 → 이번주 표시
    스토어-->>MenuBoard: selectedDate = today → 오늘 메뉴 표시

    Note over DayBar: setInterval 60s
    DayBar->>스토어: refreshToday()
    스토어->>스토어: 날짜 변경 시에만 today·minDate·maxDate 갱신

    유저->>MenuBoard: 공유 버튼 클릭
    MenuBoard->>MenuBoard: shareMenuUrl(dateStr)
    MenuBoard-->>유저: 클립보드 복사 toast
```

&nbsp;

## 주요 리뷰 요청사항

- **`refreshToday` 범위 미갱신**: midnight 갱신 시 `selectedDate`·`currentWeek`는 업데이트하지 않음. 하룻밤 열어둔 탭에서 `selectedDate < new minDate`인 상태가 발생할 수 있음. 허용 범위인지 확인 부탁드립니다.
- **`goToToday`/`refreshToday` 중복**: minDate·maxDate 계산 블록이 두 액션에 중복됨. 창 기간 변경 시 두 곳 수정 필요 — 별도 helper 추출 여부 의견 부탁드립니다.

&nbsp;

## 테스트 계획

- [ ] 모바일(640px 미만): 코스 탭 전환 시 패널 정상 표시, 단일 코스 날짜에서 탭 미노출 확인
- [ ] 데스크톱(640px 이상): 세 코스 가로 배치, 탭 UI 미표시 확인
- [ ] "오늘" 버튼: 타 주 이동 시 버튼 표시 → 클릭 시 오늘 날짜로 복귀
- [ ] DayBar 주간 레이블: 이번주/지난주/다음주 정상 표시 (일요일 포함)
- [ ] 공유 버튼: 클릭 시 `?date=YYYYMMDD` URL 클립보드 복사 toast 확인
- [ ] kcal: 각 아이템 우측 표시 + 하단 "합계 XXX kcal" 표시
- [ ] 주말(토·일) 칩 opacity 약화 시각 확인
- [ ] 주간 이동 시 오늘 포함 주 → today 선택, 아닌 주 → 월요일 선택 확인

---

> 🎭 **오늘의 커밋 시**
>
> 탭을 달아 코스를 접고 🗂️  
> 오늘 버튼 하나로 제자리로 🏠  
> kcal은 아래로 내려 합산하고 🔢  
> 자정이 오면 날짜 스스로 바뀌네 🌙  
> 주말엔 살짝 흐려, 쉬어가는 날 ☁️

🤖 Generated with [Claude Code](https://claude.com/claude-code)