### PR TITLE
feat: [다크모드] next-themes + CSS 토큰 오버라이드 방식 전체 앱 라이트/다크 테마 구현

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -58,7 +58,7 @@
 | `--color-highlight`                  | `#eedfa0`             | 헤드라인 형광펜 (코스 카테고리 레이블)               |
 | `--color-down` / `--color-down-soft` | `#6e8094` / `#e4eaf3` | 비활성/보조 버튼 그레이                              |
 
-- **테마: 라이트 단일 확정.** 다크모드 없음(`next-themes` 미사용).
+- **테마: 라이트 / 다크 지원.** `next-themes` (`attribute="data-theme"`) + CSS 토큰 오버라이드 방식. 초기값 시스템 설정, 헤더 ThemeToggle로 수동 전환, `storageKey: "megabobs-theme"`.
 - **하드코딩 금지:** 토큰 밖 그레이(`#B5B5B2` 등)는 토큰으로 흡수할 것.
 
 ## Spacing & Layout

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dayjs": "^1.11.13",
     "lucide-react": "^0.525.0",
     "next": "15.3.8",
+    "next-themes": "^0.4.6",
     "postcss": "^8.5.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       next:
         specifier: 15.3.8
         version: 15.3.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -2512,6 +2515,12 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@15.3.8:
     resolution: {integrity: sha512-L+4c5Hlr84fuaNADZbB9+ceRX9/CzwxJ+obXIGHupboB/Q1OLbSUapFs4bO8hnS/E6zV/JDX7sG1QpKVR2bguA==}
@@ -5925,6 +5934,11 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   next@15.3.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -279,6 +279,7 @@
   --color-accent-soft: #221e0a;
   --color-accent-text: #e2c04c;
   --color-down-soft: #161d27;
+  --color-highlight: #2a2208;
   --shadow-flat: 0 1px 2px rgba(0, 0, 0, 0.25);
   --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.3), 0 4px 20px rgba(0, 0, 0, 0.25);
   --shadow-card-hover:

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -264,6 +264,27 @@
   }
 }
 
+[data-theme='dark'] {
+  --color-bg: #0d1117;
+  --color-surface: #161d27;
+  --color-surface-warm: #111820;
+  --color-board: #070a0e;
+  --color-board-2: #0f1620;
+  --color-ink: #e2e8f0;
+  --color-ink-2: #8fa4bc;
+  --color-muted: #4e6070;
+  --color-line: #1e2d3e;
+  --color-cream: #c8d8e8;
+  --color-cream-2: #6a88a4;
+  --color-accent-soft: #221e0a;
+  --color-accent-text: #e2c04c;
+  --color-down-soft: #161d27;
+  --shadow-flat: 0 1px 2px rgba(0, 0, 0, 0.25);
+  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.3), 0 4px 20px rgba(0, 0, 0, 0.25);
+  --shadow-card-hover:
+    0 2px 6px rgba(0, 0, 0, 0.4), 0 8px 28px rgba(0, 0, 0, 0.35);
+}
+
 body {
   background: var(--color-bg);
   color: var(--color-ink);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -272,8 +272,8 @@
   --color-board-2: #0f1620;
   --color-ink: #e2e8f0;
   --color-ink-2: #8fa4bc;
-  --color-muted: #4e6070;
-  --color-line: #1e2d3e;
+  --color-muted: #7e8fa0;
+  --color-line: #2a3d52;
   --color-cream: #c8d8e8;
   --color-cream-2: #6a88a4;
   --color-accent-soft: #221e0a;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,11 +3,12 @@ import { Analytics } from '@vercel/analytics/next';
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import { headers } from 'next/headers';
-import { Toaster } from 'react-hot-toast';
 
 import './globals.css';
 
 import RenewalFeedbackPopup from '@/components/feedback/RenewalFeedbackPopup/RenewalFeedbackPopup';
+import ThemeProvider from '@/components/@shared/providers/ThemeProvider';
+import ToasterProvider from '@/components/@shared/providers/ToasterProvider';
 import { SITE_NAME } from '@/constants/site';
 import { SITE_DESC } from '@/utils/jsonLd';
 
@@ -98,33 +99,23 @@ export default async function RootLayout({
   const country = hdrs.get('x-vercel-ip-country');
   const isKorea = !country || country === 'KR';
   return (
-    <html lang="ko" className={pretendard.variable}>
+    <html lang="ko" className={pretendard.variable} suppressHydrationWarning>
       <head>
         {process.env.NEXT_PUBLIC_SUPABASE_URL && (
           <link rel="preconnect" href={process.env.NEXT_PUBLIC_SUPABASE_URL} />
         )}
       </head>
       <body className={bodyClass}>
-        {children}
-        <Toaster
-          position="bottom-center"
-          toastOptions={{
-            duration: 2000,
-            style: {
-              background: '#111720',
-              color: '#fff',
-              fontSize: '14px',
-              fontWeight: '500',
-              borderRadius: '0',
-            },
-          }}
-        />
-        {process.env.NEXT_PUBLIC_RENEWAL_FEEDBACK && isKorea && (
-          <RenewalFeedbackPopup
-            version={process.env.NEXT_PUBLIC_RENEWAL_FEEDBACK}
-          />
-        )}
-        {isProd && <Analytics />}
+        <ThemeProvider>
+          {children}
+          <ToasterProvider />
+          {process.env.NEXT_PUBLIC_RENEWAL_FEEDBACK && isKorea && (
+            <RenewalFeedbackPopup
+              version={process.env.NEXT_PUBLIC_RENEWAL_FEEDBACK}
+            />
+          )}
+          {isProd && <Analytics />}
+        </ThemeProvider>
       </body>
       {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && (
         <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID} />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,9 +6,9 @@ import { headers } from 'next/headers';
 
 import './globals.css';
 
-import RenewalFeedbackPopup from '@/components/feedback/RenewalFeedbackPopup/RenewalFeedbackPopup';
 import ThemeProvider from '@/components/@shared/providers/ThemeProvider';
 import ToasterProvider from '@/components/@shared/providers/ToasterProvider';
+import RenewalFeedbackPopup from '@/components/feedback/RenewalFeedbackPopup/RenewalFeedbackPopup';
 import { SITE_NAME } from '@/constants/site';
 import { SITE_DESC } from '@/utils/jsonLd';
 

--- a/src/components/@shared/layout/SiteHeader/SiteHeader.styles.ts
+++ b/src/components/@shared/layout/SiteHeader/SiteHeader.styles.ts
@@ -3,7 +3,7 @@ import { cn } from '@/utils/cn';
 export const headerClass = (scrolled: boolean, menuOpen: boolean) =>
   cn(
     'sticky top-0 z-50 transition-all duration-300',
-    (scrolled || menuOpen) && 'backdrop-blur-md'
+    (scrolled || menuOpen) && 'bg-[var(--color-bg)]/80 backdrop-blur-xl'
   );
 
 export const logoLinkClass =

--- a/src/components/@shared/layout/SiteHeader/SiteHeader.tsx
+++ b/src/components/@shared/layout/SiteHeader/SiteHeader.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react';
 
 import { getNotices } from '@/api/getNotices';
+import ThemeToggle from '@/components/@shared/ui/ThemeToggle';
 import { NAV_ITEMS, SITE_NAME } from '@/constants/site';
 import { useHasMounted } from '@/hooks/useHasMounted';
 import { getReadNoticeIds, hasNewNotice } from '@/utils/noticePolicy';
@@ -105,6 +106,7 @@ const MobileControls = ({
       className={mobileBellLinkClass}
       prefetch={prefetch}
     />
+    <ThemeToggle />
     <button
       type="button"
       aria-label={menuOpen ? '메뉴 닫기' : '메뉴 열기'}
@@ -204,6 +206,8 @@ const SiteHeader = () => {
           </Link>
 
           <DesktopNav pathname={pathname} prefetch={router.prefetch} />
+
+          <ThemeToggle />
 
           {/* 데스크톱 벨 */}
           <NoticeBell

--- a/src/components/@shared/layout/SiteHeader/SiteHeader.tsx
+++ b/src/components/@shared/layout/SiteHeader/SiteHeader.tsx
@@ -207,7 +207,9 @@ const SiteHeader = () => {
 
           <DesktopNav pathname={pathname} prefetch={router.prefetch} />
 
-          <ThemeToggle />
+          <div className="max-[640px]:hidden">
+            <ThemeToggle />
+          </div>
 
           {/* 데스크톱 벨 */}
           <NoticeBell

--- a/src/components/@shared/providers/ThemeProvider.tsx
+++ b/src/components/@shared/providers/ThemeProvider.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+import type { ReactNode } from 'react';
+
+const ThemeProvider = ({ children }: { children: ReactNode }) => (
+  <NextThemesProvider
+    attribute="data-theme"
+    defaultTheme="system"
+    enableSystem
+    storageKey="megabobs-theme"
+  >
+    {children}
+  </NextThemesProvider>
+);
+
+export default ThemeProvider;

--- a/src/components/@shared/providers/ToasterProvider.tsx
+++ b/src/components/@shared/providers/ToasterProvider.tsx
@@ -17,8 +17,8 @@ const ToasterProvider = () => {
       toastOptions={{
         duration: 2000,
         style: {
-          background: isDark ? '#161d27' : '#111720',
-          color: isDark ? '#e2e8f0' : '#fff',
+          background: isDark ? 'var(--color-surface)' : 'var(--color-board)',
+          color: isDark ? 'var(--color-ink)' : 'var(--color-surface)',
           fontSize: '14px',
           fontWeight: '500',
           borderRadius: '0',

--- a/src/components/@shared/providers/ToasterProvider.tsx
+++ b/src/components/@shared/providers/ToasterProvider.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { Toaster } from 'react-hot-toast';
+
+import { useHasMounted } from '@/hooks/useHasMounted';
+
+const ToasterProvider = () => {
+  const { resolvedTheme } = useTheme();
+  const mounted = useHasMounted();
+
+  const isDark = mounted && resolvedTheme === 'dark';
+
+  return (
+    <Toaster
+      position="bottom-center"
+      toastOptions={{
+        duration: 2000,
+        style: {
+          background: isDark ? '#161d27' : '#111720',
+          color: isDark ? '#e2e8f0' : '#fff',
+          fontSize: '14px',
+          fontWeight: '500',
+          borderRadius: '0',
+        },
+      }}
+    />
+  );
+};
+
+export default ToasterProvider;

--- a/src/components/@shared/ui/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/@shared/ui/ThemeToggle/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+
+import { useHasMounted } from '@/hooks/useHasMounted';
+
+const ThemeToggle = () => {
+  const { resolvedTheme, setTheme } = useTheme();
+  const mounted = useHasMounted();
+
+  if (!mounted) return <div className="size-9" />;
+
+  const isDark = resolvedTheme === 'dark';
+
+  return (
+    <button
+      type="button"
+      aria-label={isDark ? '라이트 모드로 전환' : '다크 모드로 전환'}
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      className="text-ink-2 flex size-9 items-center justify-center"
+    >
+      {isDark ? (
+        <Sun size={17} strokeWidth={2.2} />
+      ) : (
+        <Moon size={17} strokeWidth={2.2} />
+      )}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/@shared/ui/ThemeToggle/index.ts
+++ b/src/components/@shared/ui/ThemeToggle/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ThemeToggle';

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -32,7 +32,7 @@ export const chipRowClass = 'relative flex gap-1.5 overflow-hidden';
 export const indicatorClass = (isToday: boolean) =>
   cn(
     'pointer-events-none absolute inset-y-0 transition-transform duration-200 ease-out',
-    isToday ? 'bg-accent' : 'bg-ink'
+    isToday ? 'bg-accent' : 'bg-board'
   );
 
 export const chipBg = (isSelected: boolean): string => {
@@ -50,7 +50,7 @@ export const labelClass = (
   isToday: boolean,
   dow: number
 ): string => {
-  if (isSelected) return isToday ? 'text-ink/55' : 'text-cream-2';
+  if (isSelected) return isToday ? 'text-board/55' : 'text-cream-2';
   if (isToday) return 'text-accent-text';
   return dowColor(dow) ?? 'text-muted';
 };
@@ -60,7 +60,7 @@ export const dateClass = (
   isToday: boolean,
   dow: number
 ): string => {
-  if (isSelected) return isToday ? 'text-ink' : 'text-cream';
+  if (isSelected) return isToday ? 'text-board' : 'text-cream';
   if (isToday) return 'text-accent-text';
   return dowColor(dow) ?? 'text-ink';
 };


### PR DESCRIPTION
## 개요

> **한줄 요약**: `next-themes` + CSS 토큰 오버라이드 방식으로 앱 전체 라이트/다크 테마를 구현합니다

메가존 임직원 식당 뷰어에 다크모드가 없어 야간·저조도 환경에서 눈에 부담이 있었습니다. `next-themes` 라이브러리를 추가하고, 컴포넌트 코드 변경 없이 CSS 변수 재정의만으로 전체 테마를 전환하는 구조를 채택했습니다. 초기값은 시스템 설정을 따르고, 헤더 ThemeToggle로 수동 전환할 수 있습니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **테마 인프라** | `globals.css`, `layout.tsx` | `[data-theme='dark']` 토큰 블록 추가, ThemeProvider 래핑 |
| **신규 컴포넌트** | `ThemeProvider.tsx`, `ToasterProvider.tsx`, `ThemeToggle.tsx`, `index.ts` | 테마 프로바이더·토스터 분리, 헤더 토글 버튼 |
| **헤더 통합** | `SiteHeader.tsx`, `SiteHeader.styles.ts` | 데스크톱·모바일 ThemeToggle 삽입, frosted glass bg 토큰화 |
| **DayBar 수정** | `MenuBoardDayBar.styles.ts` | 선택 칩 인디케이터·텍스트 컬러를 `board` 토큰으로 교체 |
| **의존성** | `package.json`, `pnpm-lock.yaml` | `next-themes ^0.4.6` 추가 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 브라우저
    participant HTML
    participant ThemeProvider
    participant CSS

    브라우저->>ThemeProvider: 초기화 (system prefers-color-scheme)
    ThemeProvider->>HTML: data-theme="dark" | "light" 주입
    HTML->>CSS: [data-theme='dark'] 블록 활성화
    CSS-->>브라우저: --color-* 변수 오버라이드 → 전체 앱 자동 반응
    브라우저->>ThemeProvider: ThemeToggle 클릭
    ThemeProvider->>HTML: data-theme 교체
    ThemeProvider->>브라우저: localStorage("megabobs-theme") 저장
```

&nbsp;

## 주요 리뷰 요청사항

- `[data-theme='dark']` 블록이 Tailwind v4 `@theme` 바깥에 선언되어 있습니다. 이는 의도된 구조(CSS 변수 재정의는 `@theme` 스코프 밖에서 동작)이지만, v4 업그레이드 시 재확인이 필요할 수 있습니다.
- 토스트는 라이트 모드에서도 의도적으로 어두운 배경(`--color-board`)을 사용합니다(기존 디자인 유지).

&nbsp;

## 테스트 계획

- [ ] 라이트 모드 → ThemeToggle 클릭 → 다크 전환 확인
- [ ] 다크 모드 → ThemeToggle 클릭 → 라이트 전환 확인
- [ ] 페이지 새로고침 후 테마 유지 확인 (localStorage)
- [ ] OS 다크모드 설정 시 초기 로드 다크 적용 확인
- [ ] DayBar 선택 칩 — 라이트/다크 양 모드에서 날짜·요일 가시성 확인
- [ ] 코스 라벨(하이라이트) 다크 모드 가시성 확인
- [ ] "명이 선택했어요" 버튼 텍스트·보더 다크 모드 가시성 확인
- [ ] 기존 기능 미영향 확인

---

> 🎭 **오늘의 커밋 시**
>
> 🌙 어둠 속에서도 밥은 보여야지
> 🎨 토큰 하나 바꿔치기, 전체가 물든다
> ☀️ 헤더 위 작은 버튼, 세상을 뒤집고
> 🍱 낮에도 밤에도, 오늘 메뉴는 선명하다

🤖 Generated with [Claude Code](https://claude.com/claude-code)