### PR TITLE
feat: [이스터에그] 코스 레이블 confetti · 비행기 클릭 · 콘솔 아트

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,6 +45,33 @@
   }
 }
 
+@keyframes wiggleSm {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  25% {
+    transform: rotate(-5deg);
+  }
+  75% {
+    transform: rotate(5deg);
+  }
+}
+
+@keyframes fallFade {
+  0% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+  70% {
+    opacity: 0.7;
+  }
+  100% {
+    transform: translateY(180px) scale(0.75) rotate(15deg);
+    opacity: 0;
+  }
+}
+
 @keyframes fadeUp {
   from {
     opacity: 0;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { headers } from 'next/headers';
 
 import './globals.css';
 
+import ConsoleArt from '@/components/@shared/ConsoleArt';
 import ThemeProvider from '@/components/@shared/providers/ThemeProvider';
 import ToasterProvider from '@/components/@shared/providers/ToasterProvider';
 import RenewalFeedbackPopup from '@/components/feedback/RenewalFeedbackPopup/RenewalFeedbackPopup';
@@ -107,6 +108,7 @@ export default async function RootLayout({
       </head>
       <body className={bodyClass}>
         <ThemeProvider>
+          <ConsoleArt />
           {children}
           <ToasterProvider />
           {process.env.NEXT_PUBLIC_RENEWAL_FEEDBACK && isKorea && (

--- a/src/components/@shared/ConsoleArt/ConsoleArt.constants.ts
+++ b/src/components/@shared/ConsoleArt/ConsoleArt.constants.ts
@@ -1,0 +1,16 @@
+export const CONSOLE_ART = ` ___________________
+/                   \\
+|    MegaBobs!      |
+\\___________________/
+          \\
+           \\
+
+    / \\__
+   (    @\\___
+   /         O
+  /   (_____/
+ /_____/
+`;
+
+export const CONSOLE_ART_STYLE =
+  'color: #e2c04c; font-family: monospace; font-size: 12px; line-height: 1.5;';

--- a/src/components/@shared/ConsoleArt/ConsoleArt.tsx
+++ b/src/components/@shared/ConsoleArt/ConsoleArt.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { CONSOLE_ART, CONSOLE_ART_STYLE } from './ConsoleArt.constants';
+
+const ConsoleArt = () => {
+  useEffect(() => {
+    console.log('%c' + CONSOLE_ART, CONSOLE_ART_STYLE);
+  }, []);
+
+  return null;
+};
+
+export default ConsoleArt;

--- a/src/components/@shared/ConsoleArt/index.ts
+++ b/src/components/@shared/ConsoleArt/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ConsoleArt';

--- a/src/components/menu/MenuBoard/EasterEggOverlay/EasterEggOverlay.tsx
+++ b/src/components/menu/MenuBoard/EasterEggOverlay/EasterEggOverlay.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState } from 'react';
+
+const EMOJIS = ['🍱', '🍜', '🥗', '🍛', '🍝', '🥘'];
+const PARTICLE_COUNT = 28;
+
+type Particle = {
+  id: number;
+  emoji: string;
+  left: string;
+  duration: string;
+  delay: string;
+  size: number;
+};
+
+const generateParticles = (): Particle[] =>
+  Array.from({ length: PARTICLE_COUNT }, (_, i) => ({
+    id: i,
+    emoji: EMOJIS[i % EMOJIS.length],
+    left: `${5 + (i * 90) / PARTICLE_COUNT + (i % 3) * 3}%`,
+    duration: `${1.8 + (i % 5) * 0.15}s`,
+    delay: `${(i % 7) * 0.06}s`,
+    size: 14 + (i % 4) * 3,
+  }));
+
+const EasterEggOverlay = () => {
+  const [particles] = useState<Particle[]>(generateParticles);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 z-10 overflow-hidden"
+    >
+      {particles.map((p) => (
+        <span
+          key={p.id}
+          style={{
+            position: 'absolute',
+            top: '-30px',
+            left: p.left,
+            fontSize: `${p.size}px`,
+            animation: `fallFade ${p.duration} ${p.delay} ease-in both`,
+            lineHeight: 1,
+          }}
+        >
+          {p.emoji}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+export default EasterEggOverlay;

--- a/src/components/menu/MenuBoard/EasterEggOverlay/index.ts
+++ b/src/components/menu/MenuBoard/EasterEggOverlay/index.ts
@@ -1,0 +1,1 @@
+export { default as EasterEggOverlay } from './EasterEggOverlay';

--- a/src/components/menu/MenuBoard/MenuBoard.styles.ts
+++ b/src/components/menu/MenuBoard/MenuBoard.styles.ts
@@ -1,5 +1,5 @@
 export const sectionClass =
-  'bg-surface flex flex-col shadow-[var(--shadow-card)]';
+  'relative overflow-hidden bg-surface flex flex-col shadow-[var(--shadow-card)]';
 
 export const menuBodyClass =
   'grid grid-cols-1 min-h-[280px] min-[640px]:grid-cols-3 min-[640px]:divide-x min-[640px]:divide-line';

--- a/src/components/menu/MenuBoard/MenuBoard.tsx
+++ b/src/components/menu/MenuBoard/MenuBoard.tsx
@@ -7,6 +7,7 @@ import toast from 'react-hot-toast';
 
 import { MENU_CATEGORIES, MenuCategoryLabel } from '@/constants/menu';
 import { useDateUrl } from '@/hooks/useDateUrl';
+import { useEasterEgg } from '@/hooks/useEasterEgg';
 import { useHasMounted } from '@/hooks/useHasMounted';
 import { usePick } from '@/hooks/usePick';
 import { useVotes } from '@/hooks/useVote';
@@ -19,6 +20,7 @@ import { isAfterClose, isFutureMenuPending } from '@/utils/menuPolicy';
 import MenuBoardCourseRow from './_MenuBoardCourseRow/MenuBoardCourseRow';
 import MenuBoardDayBar from './_MenuBoardDayBar/MenuBoardDayBar';
 import MenuBoardEmpty from './_MenuBoardEmpty/MenuBoardEmpty';
+import { EasterEggOverlay } from './EasterEggOverlay';
 import {
   courseTabBarClass,
   courseTabClass,
@@ -30,6 +32,11 @@ import { MenuBoardProps } from './MenuBoard.types';
 
 const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
   useDateUrl();
+  const {
+    step: eggStep,
+    triggered: eggTriggered,
+    handleLabelClick,
+  } = useEasterEgg();
   const { today, selectedDate } = useDateStore();
   const mounted = useHasMounted();
   const [selectedTab, setSelectedTab] = useState(0);
@@ -131,6 +138,8 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
                     onPick: () => submitPick(menu.category),
                     isSubmitting: isSubmittingPick,
                   }}
+                  onHeaderClick={handleLabelClick}
+                  eggStep={eggStep}
                 />
               </div>
             );
@@ -146,6 +155,7 @@ const MenuBoard = ({ menus, isKorea }: MenuBoardProps) => {
           </div>
         )}
       </div>
+      {eggTriggered && <EasterEggOverlay />}
     </section>
   );
 };

--- a/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.styles.ts
@@ -1,3 +1,4 @@
+import type { EggStep } from '@/hooks/useEasterEgg';
 import { VoteType } from '@/models/vote';
 import { cn } from '@/utils/cn';
 
@@ -18,6 +19,12 @@ export const courseRowHeaderClass = 'mb-1.5 flex items-end gap-2';
 
 export const courseLabelClass =
   'text-accent-text text-[13px] font-extrabold tracking-wider';
+
+export const eggLabelClass = (step: EggStep): string =>
+  cn(
+    step === 2 && 'text-accent-text animate-[wiggle_0.4s_ease_both]',
+    step === 1 && 'animate-[wiggleSm_0.35s_ease_both]'
+  );
 
 export const kcalClass =
   'mt-3 flex justify-between border-t border-dashed border-line pt-3 text-accent-text text-[11px] font-semibold';

--- a/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.tsx
@@ -76,7 +76,6 @@ const MenuBoardCourseRow = ({
     <div className={courseRowClass}>
       <div className={courseRowHeaderClass}>
         <span
-          key={eggStep}
           className={cn(courseLabelClass, eggLabelClass(eggStep))}
           style={{
             background:

--- a/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.tsx
@@ -4,6 +4,7 @@ import { ThumbsDown, ThumbsUp, Users } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { MenuCategoryLabel } from '@/constants/menu';
+import { cn } from '@/utils/cn';
 
 import {
   tooltipClass,
@@ -12,6 +13,7 @@ import {
   courseLabelClass,
   downVoteButtonClass,
   downVoteIconClass,
+  eggLabelClass,
   itemKcalClass,
   itemNameClass,
   itemsTextClass,
@@ -25,7 +27,13 @@ import {
 } from './MenuBoardCourseRow.styles';
 import { MenuBoardCourseRowProps } from './MenuBoardCourseRow.types';
 
-const MenuBoardCourseRow = ({ menu, vote, pick }: MenuBoardCourseRowProps) => {
+const MenuBoardCourseRow = ({
+  menu,
+  vote,
+  pick,
+  onHeaderClick,
+  eggStep = 0,
+}: MenuBoardCourseRowProps) => {
   const [animating, setAnimating] = useState<'up' | 'down' | null>(null);
   const [longPressTarget, setLongPressTarget] = useState<'up' | 'down' | null>(
     null
@@ -68,12 +76,21 @@ const MenuBoardCourseRow = ({ menu, vote, pick }: MenuBoardCourseRowProps) => {
     <div className={courseRowClass}>
       <div className={courseRowHeaderClass}>
         <span
-          className={courseLabelClass}
+          key={eggStep}
+          className={cn(courseLabelClass, eggLabelClass(eggStep))}
           style={{
             background:
               'linear-gradient(transparent 40%, var(--color-highlight) 40%)',
             paddingInline: '2px',
           }}
+          onClick={onHeaderClick}
+          role={onHeaderClick ? 'button' : undefined}
+          tabIndex={onHeaderClick ? 0 : undefined}
+          onKeyDown={
+            onHeaderClick
+              ? (e) => e.key === 'Enter' && onHeaderClick()
+              : undefined
+          }
         >
           {MenuCategoryLabel[menu.category].ko}
         </span>

--- a/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.types.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardCourseRow/MenuBoardCourseRow.types.ts
@@ -1,3 +1,4 @@
+import { EggStep } from '@/hooks/useEasterEgg';
 import { MenuType } from '@/models/menu';
 import { VoteResult, VoteType } from '@/models/vote';
 
@@ -21,4 +22,6 @@ export interface MenuBoardCourseRowProps {
   menu: MenuType;
   vote?: VoteProps;
   pick?: PickProps;
+  onHeaderClick?: () => void;
+  eggStep?: EggStep;
 }

--- a/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.constants.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.constants.ts
@@ -1,3 +1,23 @@
+export const SPARKLE_POSITIONS = [
+  { left: '18%', bottom: '22%', size: 13, delay: '0s' },
+  { left: '42%', bottom: '12%', size: 10, delay: '-1.2s' },
+  { left: '65%', bottom: '28%', size: 12, delay: '-2.4s' },
+  { left: '80%', bottom: '15%', size: 9, delay: '-0.6s' },
+] as const;
+
+export const PLANE_CONFIGS = [
+  { size: 15, duration: 7, delay: 0, opacity: 1, top: '50%' },
+  { size: 12, duration: 7, delay: -3.5, opacity: 0.5, top: '50%' },
+  { size: 10, duration: 5.5, delay: -1.5, opacity: 0.75, top: '30%' },
+  { size: 17, duration: 9, delay: -4.5, opacity: 0.65, top: '65%' },
+  { size: 8, duration: 6, delay: -2, opacity: 0.8, top: '20%' },
+  { size: 14, duration: 8, delay: -5, opacity: 0.6, top: '75%' },
+  { size: 11, duration: 4.5, delay: -1, opacity: 0.85, top: '40%' },
+  { size: 16, duration: 7.5, delay: -3, opacity: 0.45, top: '60%' },
+] as const;
+
+export const INITIAL_PLANE_COUNT = 2;
+
 export const BOARD_EMPTY_COPY = {
   closed: {
     label: '휴무',

--- a/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.styles.ts
@@ -1,3 +1,8 @@
+export const planeWrapperClass =
+  'absolute inset-0 cursor-pointer transition-opacity duration-300';
+
+export const planeClass = 'text-muted absolute left-1/2 -translate-y-1/2';
+
 export const emptyLabelClass =
   'text-accent-text text-[13px] font-black tracking-wider';
 

--- a/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
@@ -1,21 +1,23 @@
 'use client';
 
+import { useState } from 'react';
+
 import { Plane, Sparkles } from 'lucide-react';
 
-import { BOARD_EMPTY_COPY } from './MenuBoardEmpty.constants';
+import {
+  BOARD_EMPTY_COPY,
+  INITIAL_PLANE_COUNT,
+  PLANE_CONFIGS,
+  SPARKLE_POSITIONS,
+} from './MenuBoardEmpty.constants';
 import {
   emptyBodyClass,
   emptyLabelClass,
   emptyTitleClass,
+  planeClass,
+  planeWrapperClass,
 } from './MenuBoardEmpty.styles';
 import { MenuBoardEmptyProps } from './MenuBoardEmpty.types';
-
-const SPARKLE_POSITIONS = [
-  { left: '18%', bottom: '22%', size: 13, delay: '0s' },
-  { left: '42%', bottom: '12%', size: 10, delay: '-1.2s' },
-  { left: '65%', bottom: '28%', size: 12, delay: '-2.4s' },
-  { left: '80%', bottom: '15%', size: 9, delay: '-0.6s' },
-];
 
 const MenuBoardEmpty = ({
   variant,
@@ -24,6 +26,13 @@ const MenuBoardEmpty = ({
   isPast,
 }: MenuBoardEmptyProps) => {
   const copy = BOARD_EMPTY_COPY[variant];
+  const [planeCount, setPlaneCount] = useState(INITIAL_PLANE_COUNT);
+
+  const handlePlaneClick = () => {
+    setPlaneCount((prev) =>
+      prev >= PLANE_CONFIGS.length ? INITIAL_PLANE_COUNT : prev + 1
+    );
+  };
 
   const closedTitle = (() => {
     if (variant !== 'closed') return copy.title;
@@ -38,19 +47,24 @@ const MenuBoardEmpty = ({
   return (
     <div className="relative flex h-full flex-col items-center justify-center overflow-hidden px-6 py-12 text-center">
       {variant === 'closed' && (
-        <div className="pointer-events-none absolute inset-0" aria-hidden>
-          <span
-            className="text-muted absolute top-1/2 left-1/2 -translate-y-1/2"
-            style={{ animation: 'planeFly 7s linear infinite' }}
-          >
-            <Plane size={15} strokeWidth={1.5} />
-          </span>
-          <span
-            className="text-muted absolute top-1/2 left-1/2 -translate-y-1/2 opacity-50"
-            style={{ animation: 'planeFly 7s linear -3.5s infinite' }}
-          >
-            <Plane size={12} strokeWidth={1.5} />
-          </span>
+        <div
+          aria-hidden
+          className={planeWrapperClass}
+          onClick={handlePlaneClick}
+        >
+          {PLANE_CONFIGS.slice(0, planeCount).map((cfg, i) => (
+            <span
+              key={i}
+              className={planeClass}
+              style={{
+                top: cfg.top,
+                opacity: cfg.opacity,
+                animation: `planeFly ${cfg.duration}s linear ${cfg.delay}s infinite`,
+              }}
+            >
+              <Plane size={cfg.size} strokeWidth={1.5} />
+            </span>
+          ))}
         </div>
       )}
       {variant === 'comingUp' && (

--- a/src/hooks/useEasterEgg.test.ts
+++ b/src/hooks/useEasterEgg.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { calcEggStep } from './useEasterEgg';
+
+describe('calcEggStep', () => {
+  it('returns 0 for clicks 0-2', () => {
+    expect(calcEggStep(0)).toBe(0);
+    expect(calcEggStep(1)).toBe(0);
+    expect(calcEggStep(2)).toBe(0);
+  });
+
+  it('returns 1 for click count 3', () => {
+    expect(calcEggStep(3)).toBe(1);
+  });
+
+  it('returns 2 for click count 4', () => {
+    expect(calcEggStep(4)).toBe(2);
+  });
+
+  it('returns 2 for counts above 4', () => {
+    expect(calcEggStep(5)).toBe(2);
+    expect(calcEggStep(10)).toBe(2);
+  });
+});

--- a/src/hooks/useEasterEgg.ts
+++ b/src/hooks/useEasterEgg.ts
@@ -15,6 +15,7 @@ export const calcEggStep = (clickCount: number): EggStep => {
 export const useEasterEgg = () => {
   const [clickCount, setClickCount] = useState(0);
   const [triggered, setTriggered] = useState(false);
+  const clickCountRef = useRef(0);
   const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const step = calcEggStep(clickCount);
@@ -22,19 +23,24 @@ export const useEasterEgg = () => {
   const handleLabelClick = useCallback(() => {
     if (triggered) return;
 
-    const next = clickCount + 1;
+    const next = clickCountRef.current + 1;
 
     if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
 
     if (next >= THRESHOLD) {
+      clickCountRef.current = 0;
       setTriggered(true);
       setClickCount(0);
       return;
     }
 
+    clickCountRef.current = next;
     setClickCount(next);
-    resetTimerRef.current = setTimeout(() => setClickCount(0), TIMEOUT_MS);
-  }, [triggered, clickCount]);
+    resetTimerRef.current = setTimeout(() => {
+      clickCountRef.current = 0;
+      setClickCount(0);
+    }, TIMEOUT_MS);
+  }, [triggered]);
 
   useEffect(() => {
     if (!triggered) return;

--- a/src/hooks/useEasterEgg.ts
+++ b/src/hooks/useEasterEgg.ts
@@ -22,20 +22,19 @@ export const useEasterEgg = () => {
   const handleLabelClick = useCallback(() => {
     if (triggered) return;
 
-    setClickCount((prev) => {
-      const next = prev + 1;
+    const next = clickCount + 1;
 
-      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
 
-      if (next >= THRESHOLD) {
-        setTriggered(true);
-        return 0;
-      }
+    if (next >= THRESHOLD) {
+      setTriggered(true);
+      setClickCount(0);
+      return;
+    }
 
-      resetTimerRef.current = setTimeout(() => setClickCount(0), TIMEOUT_MS);
-      return next;
-    });
-  }, [triggered]);
+    setClickCount(next);
+    resetTimerRef.current = setTimeout(() => setClickCount(0), TIMEOUT_MS);
+  }, [triggered, clickCount]);
 
   useEffect(() => {
     if (!triggered) return;

--- a/src/hooks/useEasterEgg.ts
+++ b/src/hooks/useEasterEgg.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type EggStep = 0 | 1 | 2;
+
+const THRESHOLD = 5;
+const TIMEOUT_MS = 3000;
+const TRIGGERED_DURATION_MS = 3000;
+
+export const calcEggStep = (clickCount: number): EggStep => {
+  if (clickCount >= 4) return 2;
+  if (clickCount >= 3) return 1;
+  return 0;
+};
+
+export const useEasterEgg = () => {
+  const [clickCount, setClickCount] = useState(0);
+  const [triggered, setTriggered] = useState(false);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const step = calcEggStep(clickCount);
+
+  const handleLabelClick = useCallback(() => {
+    if (triggered) return;
+
+    setClickCount((prev) => {
+      const next = prev + 1;
+
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+
+      if (next >= THRESHOLD) {
+        setTriggered(true);
+        return 0;
+      }
+
+      resetTimerRef.current = setTimeout(() => setClickCount(0), TIMEOUT_MS);
+      return next;
+    });
+  }, [triggered]);
+
+  useEffect(() => {
+    if (!triggered) return;
+    const id = setTimeout(() => setTriggered(false), TRIGGERED_DURATION_MS);
+    return () => clearTimeout(id);
+  }, [triggered]);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    };
+  }, []);
+
+  return { step, triggered, handleLabelClick };
+};


### PR DESCRIPTION
## 개요

> **한줄 요약**: 메가밥스에 숨겨진 인터랙션 3종 (코스 레이블 confetti, 휴무 비행기, 콘솔 ASCII 아트)을 추가합니다.

임직원이 일상적으로 쓰는 서비스에 작은 재미 요소를 심어, 발견한 사람만 아는 즐거움을 줍니다. 모든 이스터에그는 기존 UI·기능에 영향을 주지 않도록 설계했습니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **이스터에그 훅** | `useEasterEgg.ts`, `useEasterEgg.test.ts` | 클릭 카운트·단계·발동 상태 관리 훅 구현 |
| **파티클 confetti** | `EasterEggOverlay.tsx`, `index.ts` | 5회 클릭 시 음식 이모지 28개 낙하 애니메이션 |
| **코스 레이블 인터랙션** | `MenuBoardCourseRow.tsx`, `MenuBoardCourseRow.styles.ts`, `MenuBoardCourseRow.types.ts` | 클릭 단계별 wiggle 피드백 + 키보드 접근성 |
| **메뉴판 통합** | `MenuBoard.tsx`, `MenuBoard.styles.ts` | useEasterEgg 연결, EasterEggOverlay 조건부 렌더 |
| **휴무 화면** | `MenuBoardEmpty.tsx`, `MenuBoardEmpty.constants.ts`, `MenuBoardEmpty.styles.ts` | 비행기 클릭 시 2→8대 단계적 추가 후 리셋 |
| **콘솔 아트** | `ConsoleArt.tsx`, `ConsoleArt.constants.ts`, `index.ts` | 개발자 콘솔 ASCII 강아지 아트 출력 |
| **애니메이션** | `globals.css` | wiggleSm · fallFade keyframe 추가 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 유저
    participant 레이블 as 코스 레이블
    participant 훅 as useEasterEgg
    participant 오버레이 as EasterEggOverlay

    유저->>레이블: 클릭 (1~4회)
    레이블->>훅: handleLabelClick()
    훅-->>레이블: step 1/2 → wiggle 애니메이션
    유저->>레이블: 5번째 클릭
    훅-->>오버레이: triggered=true → 마운트
    오버레이-->>유저: 음식 이모지 낙하 (3초)
    훅-->>오버레이: triggered=false → 언마운트
```

&nbsp;

## 테스트 계획

- [ ] 코스 레이블 5회 클릭 → confetti 발동 확인
- [ ] 3회 클릭 시 wiggleSm, 4회 클릭 시 wiggle 애니메이션 확인
- [ ] 3초 비활성 후 클릭 카운트 리셋 확인
- [ ] 빠른 연속 클릭 5회 시 정확히 발동 확인 (stale closure 수정 검증)
- [ ] 휴무 화면 비행기 클릭 → 2→3→...→8→2대 순환 확인
- [ ] 개발자 콘솔 ASCII 아트 출력 확인 (F12)
- [ ] 키보드(Tab + Enter)로 코스 레이블 클릭 가능 확인
- [ ] 기존 투표·픽 기능 미영향 확인

---

> 🎭 **오늘의 커밋 시**
>
> 점심 종치면 오늘도 고민이지 🤔
> 코스 레이블 콕콕 다섯 번 누르면 🖱️
> 이모지 비 쏟아지고 비행기도 뜨고 ✈️
> 콘솔 열면 강아지가 반겨줘요 🐕

🤖 Generated with [Claude Code](https://claude.com/claude-code)