### PR TITLE
feat: [버전 관리] 앱 버전 자동 주입 및 main 머지 시 semver 자동 bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,69 @@
+name: Auto Version Bump
+
+# main에 머지될 때마다 커밋 메시지를 파싱해 semver를 자동 bump한다.
+# feat: → minor / 그 외(fix/refactor/chore 등) → patch / !: → major
+# bump 커밋에 [skip ci]를 포함해 무한 루프를 방지한다.
+#
+# 주의: main 브랜치 보호 규칙이 있으면 GITHUB_TOKEN 대신
+#       PAT(contents:write)를 secrets.VERSION_BUMP_TOKEN에 등록해야 한다.
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  version-bump:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine bump type from commit message
+        id: bump
+        run: |
+          MSG="${{ github.event.head_commit.message }}"
+          if echo "$MSG" | grep -qE '^[a-z]+(\(.+\))?!:'; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif echo "$MSG" | grep -qE '^feat(\(.+\))?:'; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          else
+            echo "type=patch" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Bump version and push
+        id: version
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          pnpm version ${{ steps.bump.outputs.type }} --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          git add package.json
+          git commit -m "chore: bump version to v${NEW_VERSION} [skip ci]"
+          git push
+          echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="v${{ steps.version.outputs.version }}"
+          git tag "${VERSION}"
+          git push origin "${VERSION}"
+          gh release create "${VERSION}" \
+            --title "${VERSION}" \
+            --generate-notes

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,10 @@
 import type { NextConfig } from 'next';
+import { version } from './package.json';
 
 const nextConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_APP_VERSION: version,
+  },
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mega-bobs",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -124,9 +124,9 @@ export default async function RootLayout({
           <ConsoleArt />
           {children}
           <ToasterProvider />
-          {process.env.NEXT_PUBLIC_RENEWAL_FEEDBACK && isKorea && (
+          {isKorea && (
             <RenewalFeedbackPopup
-              version={process.env.NEXT_PUBLIC_RENEWAL_FEEDBACK}
+              version={process.env.NEXT_PUBLIC_APP_VERSION ?? 'unknown'}
             />
           )}
           {isProd && <Analytics />}


### PR DESCRIPTION
## 개요

> **한줄 요약**: 배포마다 수기 입력하던 피드백 버전을 package.json 기반으로 자동화하고, main 머지 시 semver bump·태그·릴리즈까지 CI가 처리하도록 변경

피드백 팝업 버전을 Vercel 환경변수(`NEXT_PUBLIC_RENEWAL_FEEDBACK`)에 직접 입력해야 했던 번거로움을 제거합니다.  
빌드 타임에 `package.json` 버전을 주입하고, main 브랜치에 머지될 때마다 conventional commit 규칙에 따라 버전이 자동 bump됩니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
|---|---|---|
| **버전 자동 주입** | `next.config.ts`, `layout.tsx` | 빌드 타임에 `NEXT_PUBLIC_APP_VERSION` 주입, `NEXT_PUBLIC_RENEWAL_FEEDBACK` 제거 |
| **CI 자동화** | `version-bump.yml` | main 머지 시 semver bump + git 태그 + GitHub Release 자동 생성 |
| **버전 초기화** | `package.json` | 현재 릴리즈(`1.0.1`)와 동기화 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 개발자
    participant GitHub Actions
    participant package.json
    participant GitHub

    개발자->>GitHub: feat: ... 커밋 머지 (main)
    GitHub Actions->>package.json: 커밋 메시지 파싱 → minor bump
    package.json-->>GitHub Actions: version 1.0.1 → 1.1.0
    GitHub Actions->>GitHub: chore: bump version to v1.1.0 [skip ci] 커밋
    GitHub Actions->>GitHub: git tag v1.1.0 + Release 생성
```

&nbsp;

## 테스트 계획

- [ ] `pnpm dev` 실행 후 브라우저 콘솔에서 `process.env.NEXT_PUBLIC_APP_VERSION` 값 확인
- [ ] 피드백 팝업이 정상 노출되고 버전이 `1.0.1`로 표시되는지 확인
- [ ] test 브랜치를 main에 머지해 Actions 워크플로우 동작 확인 (bump 커밋·태그·릴리즈 생성)
- [ ] `feat:` 커밋 → minor bump, `fix:` 커밋 → patch bump 확인
- [ ] 기존 `NEXT_PUBLIC_RENEWAL_FEEDBACK` 없어도 팝업 정상 동작 확인

---

> 🎭 **오늘의 커밋 시**
>
> 손가락으로 버전 적던 시절은 끝났어 🖊️  
> package.json이 알아서 세어줄 테니까  
> feat 하나면 minor, fix 하나면 patch 🔖  
> 태그도 릴리즈도 봇이 붙여줘 🤖  
> 이제 우린 코드만 쓰면 돼 ✨

🤖 Generated with [Claude Code](https://claude.com/claude-code)