### PR TITLE
style: [UI 폴리시] 날짜 그리드·코스 탭 스타일 개선 및 GA 프로덕션 전용 전환

### DIFF
--- a/src/app/api/slack/_utils.ts
+++ b/src/app/api/slack/_utils.ts
@@ -3,7 +3,6 @@ import { unstable_cache } from 'next/cache';
 import getMenu from '@/api/getMenu';
 import { MENU_CATEGORIES, MenuCategoryLabel } from '@/constants/menu';
 import { SITE_NAME } from '@/constants/site';
-import { SITE_URL } from '@/utils/env';
 import {
   CommandKeyword,
   DAY_OFFSET_MAP,
@@ -11,6 +10,7 @@ import {
 } from '@/constants/slack';
 import dayjs, { SEOUL_TIMEZONE } from '@/lib/dayjs';
 import { MenuCategory, MenuType } from '@/models/menu';
+import { SITE_URL } from '@/utils/env';
 
 export const getCachedMenu = unstable_cache(
   (date: string) => getMenu({ start: date, end: date }),

--- a/src/app/api/votes/route.ts
+++ b/src/app/api/votes/route.ts
@@ -95,14 +95,16 @@ export const POST = async (req: NextRequest) => {
       return NextResponse.json({ error: error.message }, { status: 500 });
 
     if (vote_type) {
-      const { error: geoError } = await supabaseServer
+      void supabaseServer
         .from('menu_votes')
         .update({ ip: geo.ip })
         .eq('voter_id', voterId)
         .eq('menu_key', menu_key)
-        .eq('date', date);
-      if (geoError)
-        console.error('[votes] geo update failed:', geoError.message);
+        .eq('date', date)
+        .then(({ error: geoError }) => {
+          if (geoError)
+            console.error('[votes] geo update failed:', geoError.message);
+        });
     }
 
     return NextResponse.json({ ok: true });

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -1,6 +1,6 @@
+import { Gamepad2 } from 'lucide-react';
 import type { Metadata } from 'next';
 
-import { Gamepad2 } from 'lucide-react';
 
 import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
 import { GameCard } from '@/components/games';

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,6 +1,6 @@
+import { Newspaper } from 'lucide-react';
 import type { Metadata } from 'next';
 
-import { Newspaper } from 'lucide-react';
 
 import getNews, { getLastCrawledAt } from '@/api/getNews';
 import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 
-import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
 import {
   legalSectionBodyClass,
   legalSectionClass,
@@ -14,6 +13,7 @@ import {
   tocTitleClass,
   tocWrapClass,
 } from '@/app/legal.styles';
+import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
 import { SITE_NAME } from '@/constants/site';
 
 export const metadata: Metadata = {

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -8,12 +8,9 @@ import {
   legalSectionTdClass,
   legalSectionThClass,
   legalSectionTitleClass,
-  tocLinkClass,
-  tocListClass,
-  tocTitleClass,
-  tocWrapClass,
 } from '@/app/legal.styles';
 import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
+import LegalTocNav from '@/components/legal/LegalTocNav/LegalTocNav';
 import { SITE_NAME } from '@/constants/site';
 
 export const metadata: Metadata = {
@@ -40,18 +37,7 @@ const PrivacyPage = () => (
       title="개인정보처리방침"
       subtitle="최종 업데이트: 2026. 6. 8."
     >
-      <nav aria-label="목차" className={tocWrapClass}>
-        <p className={tocTitleClass}>목차</p>
-        <ol className={tocListClass}>
-          {TOC_ITEMS.map((item, i) => (
-            <li key={item.id}>
-              <a href={`#${item.id}`} className={tocLinkClass}>
-                {i + 1}. {item.label}
-              </a>
-            </li>
-          ))}
-        </ol>
-      </nav>
+      <LegalTocNav items={TOC_ITEMS} />
 
       <section id="collected-info" className={legalSectionClass}>
         <h2 className={legalSectionTitleClass}>1. 수집하는 정보</h2>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 
-import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
 import {
   legalSectionBodyClass,
   legalSectionClass,
@@ -11,6 +10,7 @@ import {
   tocTitleClass,
   tocWrapClass,
 } from '@/app/legal.styles';
+import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
 import { SITE_NAME } from '@/constants/site';
 
 export const metadata: Metadata = {

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -5,12 +5,9 @@ import {
   legalSectionClass,
   legalSectionListClass,
   legalSectionTitleClass,
-  tocLinkClass,
-  tocListClass,
-  tocTitleClass,
-  tocWrapClass,
 } from '@/app/legal.styles';
 import { PageLayout, SiteFooter, SiteHeader } from '@/components/@shared';
+import LegalTocNav from '@/components/legal/LegalTocNav/LegalTocNav';
 import { SITE_NAME } from '@/constants/site';
 
 export const metadata: Metadata = {
@@ -38,18 +35,7 @@ const TermsPage = () => (
       title="이용약관"
       subtitle="최종 업데이트: 2026. 6. 8."
     >
-      <nav aria-label="목차" className={tocWrapClass}>
-        <p className={tocTitleClass}>목차</p>
-        <ol className={tocListClass}>
-          {TOC_ITEMS.map((item, i) => (
-            <li key={item.id}>
-              <a href={`#${item.id}`} className={tocLinkClass}>
-                {i + 1}. {item.label}
-              </a>
-            </li>
-          ))}
-        </ol>
-      </nav>
+      <LegalTocNav items={TOC_ITEMS} />
 
       <section id="service-overview" className={legalSectionClass}>
         <h2 className={legalSectionTitleClass}>1. 서비스 개요</h2>

--- a/src/components/@shared/ConsoleArt/ConsoleArt.tsx
+++ b/src/components/@shared/ConsoleArt/ConsoleArt.tsx
@@ -6,7 +6,7 @@ import { CONSOLE_ART, CONSOLE_ART_STYLE } from './ConsoleArt.constants';
 
 const ConsoleArt = () => {
   useEffect(() => {
-    console.log('%c' + CONSOLE_ART, CONSOLE_ART_STYLE);
+    console.log(`%c${  CONSOLE_ART}`, CONSOLE_ART_STYLE);
   }, []);
 
   return null;

--- a/src/components/@shared/layout/PageLayout/PageLayout.styles.ts
+++ b/src/components/@shared/layout/PageLayout/PageLayout.styles.ts
@@ -1,4 +1,6 @@
-export const pageMainClass = 'mx-auto w-[min(880px,calc(100%-40px))] flex-1';
+export const CONTENT_WIDTH_CLASS = 'w-[min(880px,calc(100%-40px))]';
+
+export const pageMainClass = `mx-auto ${CONTENT_WIDTH_CLASS} flex-1`;
 
 export const pageHeaderClass =
   'flex flex-col justify-start pt-12 pb-6 min-h-[168px] max-[640px]:pt-4 max-[640px]:pb-2 max-[640px]:min-h-0';

--- a/src/components/@shared/layout/SiteFooter/SiteFooter.tsx
+++ b/src/components/@shared/layout/SiteFooter/SiteFooter.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { CONTENT_WIDTH_CLASS } from '@/components/@shared/layout/PageLayout/PageLayout.styles';
 import { FOOTER_LINKS, SITE_NAME } from '@/constants/site';
 
 import {
@@ -11,7 +12,7 @@ import {
 
 const SiteFooter = () => (
   <footer className="mt-8">
-    <div className="mx-auto w-[min(880px,calc(100%-40px))] py-6">
+    <div className={`mx-auto ${CONTENT_WIDTH_CLASS} py-6`}>
       <div className="flex flex-col items-center gap-4 text-center min-[560px]:flex-row min-[560px]:items-center min-[560px]:justify-between min-[560px]:gap-0 min-[560px]:text-left">
         {/* 브랜드 단 */}
         <div className="flex flex-col items-center gap-1 min-[560px]:flex-row min-[560px]:gap-5">

--- a/src/components/@shared/layout/SiteHeader/SiteHeader.tsx
+++ b/src/components/@shared/layout/SiteHeader/SiteHeader.tsx
@@ -14,6 +14,8 @@ import {
   NOTICE_READ_EVENT,
 } from '@/utils/noticePolicy';
 
+import { CONTENT_WIDTH_CLASS } from '../PageLayout/PageLayout.styles';
+
 import DesktopNav from './_DesktopNav/DesktopNav';
 import MobileControls from './_MobileControls/MobileControls';
 import MobileOverlay from './_MobileOverlay/MobileOverlay';
@@ -69,7 +71,9 @@ const SiteHeader = () => {
   return (
     <>
       <header className={headerClass(scrolled, menuOpen)}>
-        <div className="mx-auto flex h-14 w-[min(880px,calc(100%-40px))] items-center gap-7">
+        <div
+          className={`mx-auto flex h-14 ${CONTENT_WIDTH_CLASS} items-center gap-7`}
+        >
           <Link href="/" className={logoLinkClass}>
             {SITE_NAME}
           </Link>

--- a/src/components/@shared/layout/SiteHeader/SiteHeader.tsx
+++ b/src/components/@shared/layout/SiteHeader/SiteHeader.tsx
@@ -14,15 +14,15 @@ import {
   NOTICE_READ_EVENT,
 } from '@/utils/noticePolicy';
 
+import DesktopNav from './_DesktopNav/DesktopNav';
+import MobileControls from './_MobileControls/MobileControls';
+import MobileOverlay from './_MobileOverlay/MobileOverlay';
+import NoticeBell from './_NoticeBell/NoticeBell';
 import {
   desktopBellLinkClass,
   headerClass,
   logoLinkClass,
 } from './SiteHeader.styles';
-import DesktopNav from './_DesktopNav/DesktopNav';
-import MobileControls from './_MobileControls/MobileControls';
-import MobileOverlay from './_MobileOverlay/MobileOverlay';
-import NoticeBell from './_NoticeBell/NoticeBell';
 
 const SiteHeader = () => {
   const pathname = usePathname();

--- a/src/components/@shared/layout/SiteHeader/_DesktopNav/DesktopNav.tsx
+++ b/src/components/@shared/layout/SiteHeader/_DesktopNav/DesktopNav.tsx
@@ -3,11 +3,11 @@ import Link from 'next/link';
 import { NAV_ITEMS } from '@/constants/site';
 
 import {
-  comingSoonBadgeClass,
   desktopComingSoonClass,
   desktopNavClass,
   desktopNavLinkClass,
 } from '../SiteHeader.styles';
+import NavComingSoonItem from '../_NavComingSoonItem/NavComingSoonItem';
 
 const DesktopNav = ({
   pathname,
@@ -20,10 +20,11 @@ const DesktopNav = ({
     {NAV_ITEMS.map((item) => {
       if (item.comingSoon) {
         return (
-          <span key={item.href} className={desktopComingSoonClass}>
-            {item.label}
-            <span className={comingSoonBadgeClass}>준비중</span>
-          </span>
+          <NavComingSoonItem
+            key={item.href}
+            label={item.label}
+            className={desktopComingSoonClass}
+          />
         );
       }
       const active = pathname === item.href;

--- a/src/components/@shared/layout/SiteHeader/_DesktopNav/DesktopNav.tsx
+++ b/src/components/@shared/layout/SiteHeader/_DesktopNav/DesktopNav.tsx
@@ -2,12 +2,12 @@ import Link from 'next/link';
 
 import { NAV_ITEMS } from '@/constants/site';
 
+import NavComingSoonItem from '../_NavComingSoonItem/NavComingSoonItem';
 import {
   desktopComingSoonClass,
   desktopNavClass,
   desktopNavLinkClass,
 } from '../SiteHeader.styles';
-import NavComingSoonItem from '../_NavComingSoonItem/NavComingSoonItem';
 
 const DesktopNav = ({
   pathname,

--- a/src/components/@shared/layout/SiteHeader/_MobileControls/MobileControls.tsx
+++ b/src/components/@shared/layout/SiteHeader/_MobileControls/MobileControls.tsx
@@ -3,11 +3,11 @@ import type { Dispatch, SetStateAction } from 'react';
 
 import ThemeToggle from '@/components/@shared/ui/ThemeToggle';
 
+import NoticeBell from '../_NoticeBell/NoticeBell';
 import {
   mobileBellLinkClass,
   mobileMenuButtonClass,
 } from '../SiteHeader.styles';
-import NoticeBell from '../_NoticeBell/NoticeBell';
 
 const MobileControls = ({
   menuOpen,

--- a/src/components/@shared/layout/SiteHeader/_MobileOverlay/MobileOverlay.tsx
+++ b/src/components/@shared/layout/SiteHeader/_MobileOverlay/MobileOverlay.tsx
@@ -4,12 +4,13 @@ import type { Dispatch, SetStateAction } from 'react';
 
 import { NAV_ITEMS } from '@/constants/site';
 
+import { CONTENT_WIDTH_CLASS } from '../../PageLayout/PageLayout.styles';
+import NavComingSoonItem from '../_NavComingSoonItem/NavComingSoonItem';
 import {
   mobileComingSoonClass,
   mobileNavLinkClass,
   mobileOverlayClass,
 } from '../SiteHeader.styles';
-import NavComingSoonItem from '../_NavComingSoonItem/NavComingSoonItem';
 
 const MobileOverlay = ({
   menuOpen,
@@ -23,7 +24,7 @@ const MobileOverlay = ({
   prefetch: (href: string) => void;
 }) => (
   <div className={mobileOverlayClass(menuOpen)}>
-    <nav className="mx-auto flex w-[min(880px,calc(100%-40px))] flex-col pt-1 pb-4">
+    <nav className={`mx-auto flex ${CONTENT_WIDTH_CLASS} flex-col pt-1 pb-4`}>
       {NAV_ITEMS.map((item) => {
         if (item.comingSoon) {
           return (

--- a/src/components/@shared/layout/SiteHeader/_MobileOverlay/MobileOverlay.tsx
+++ b/src/components/@shared/layout/SiteHeader/_MobileOverlay/MobileOverlay.tsx
@@ -5,11 +5,11 @@ import type { Dispatch, SetStateAction } from 'react';
 import { NAV_ITEMS } from '@/constants/site';
 
 import {
-  comingSoonBadgeClass,
   mobileComingSoonClass,
   mobileNavLinkClass,
   mobileOverlayClass,
 } from '../SiteHeader.styles';
+import NavComingSoonItem from '../_NavComingSoonItem/NavComingSoonItem';
 
 const MobileOverlay = ({
   menuOpen,
@@ -27,10 +27,11 @@ const MobileOverlay = ({
       {NAV_ITEMS.map((item) => {
         if (item.comingSoon) {
           return (
-            <span key={item.href} className={mobileComingSoonClass}>
-              {item.label}
-              <span className={comingSoonBadgeClass}>준비중</span>
-            </span>
+            <NavComingSoonItem
+              key={item.href}
+              label={item.label}
+              className={mobileComingSoonClass}
+            />
           );
         }
         const active = pathname === item.href;

--- a/src/components/@shared/layout/SiteHeader/_NavComingSoonItem/NavComingSoonItem.tsx
+++ b/src/components/@shared/layout/SiteHeader/_NavComingSoonItem/NavComingSoonItem.tsx
@@ -1,0 +1,16 @@
+import { comingSoonBadgeClass } from '../SiteHeader.styles';
+
+const NavComingSoonItem = ({
+  label,
+  className,
+}: {
+  label: string;
+  className: string;
+}) => (
+  <span className={className}>
+    {label}
+    <span className={comingSoonBadgeClass}>준비중</span>
+  </span>
+);
+
+export default NavComingSoonItem;

--- a/src/components/legal/LegalTocNav/LegalTocNav.tsx
+++ b/src/components/legal/LegalTocNav/LegalTocNav.tsx
@@ -1,0 +1,25 @@
+import {
+  tocLinkClass,
+  tocListClass,
+  tocTitleClass,
+  tocWrapClass,
+} from '@/app/legal.styles';
+
+type TocItem = { id: string; label: string };
+
+const LegalTocNav = ({ items }: { items: TocItem[] }) => (
+  <nav aria-label="목차" className={tocWrapClass}>
+    <p className={tocTitleClass}>목차</p>
+    <ol className={tocListClass}>
+      {items.map((item, i) => (
+        <li key={item.id}>
+          <a href={`#${item.id}`} className={tocLinkClass}>
+            {i + 1}. {item.label}
+          </a>
+        </li>
+      ))}
+    </ol>
+  </nav>
+);
+
+export default LegalTocNav;

--- a/src/components/menu/MenuBoard/MenuBoard.styles.ts
+++ b/src/components/menu/MenuBoard/MenuBoard.styles.ts
@@ -13,5 +13,5 @@ export const courseTabBarClass = 'flex gap-1 px-2 pt-0 pb-0 min-[640px]:hidden';
 
 export const courseTabClass = (active: boolean) =>
   active
-    ? 'flex-1 rounded-lg py-2.5 text-[13px] font-bold text-ink bg-accent dark:bg-line dark:text-cream text-center transition-colors'
-    : 'flex-1 rounded-lg py-2.5 text-[13px] font-semibold text-muted bg-bg/80 text-center transition-colors hover:text-ink hover:bg-surface-warm';
+    ? 'flex-1 py-2.5 text-[13px] font-bold text-ink bg-accent dark:bg-line dark:text-cream text-center transition-colors'
+    : 'flex-1 py-2.5 text-[13px] font-semibold text-muted bg-bg/80 text-center transition-colors hover:text-ink hover:bg-surface-warm';

--- a/src/components/menu/MenuBoard/MenuBoard.tsx
+++ b/src/components/menu/MenuBoard/MenuBoard.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState } from 'react';
 
-import { cn } from '@/utils/cn';
 
 import { MENU_CATEGORIES, MenuCategoryLabel } from '@/constants/menu';
 import { useDateUrl } from '@/hooks/useDateUrl';
@@ -12,6 +11,7 @@ import { usePick } from '@/hooks/usePick';
 import { useVotes } from '@/hooks/useVote';
 import dayjs from '@/lib/dayjs';
 import { useDateStore } from '@/store/useDateStore';
+import { cn } from '@/utils/cn';
 import { formatYYYYMMDD } from '@/utils/date';
 import { isAfterClose, isFutureMenuPending } from '@/utils/menuPolicy';
 

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -52,11 +52,7 @@ export const dayDowClass = (
           : 'text-ink-2'
   );
 
-export const dayDateClass = (
-  isSelected: boolean,
-  isToday: boolean,
-  _dow: number
-) =>
+export const dayDateClass = (isSelected: boolean, isToday: boolean) =>
   cn(
     'text-[11px] font-[500] tabular-nums leading-none',
     isSelected ? 'text-ink-2' : isToday ? 'text-accent-text' : 'text-muted'

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -28,9 +28,7 @@ export const dayGridClass = 'grid grid-cols-7 gap-1 px-2 pb-1';
 export const dayColumnClass = (isSelected: boolean) =>
   cn(
     'relative flex min-h-[44px] cursor-pointer flex-col items-center justify-center gap-1 rounded-t-lg py-2.5 transition-colors',
-    isSelected
-      ? 'bg-line/60 hover:bg-line/60'
-      : 'bg-bg/50 hover:bg-surface-warm'
+    isSelected ? 'hover:bg-line/60' : 'hover:bg-surface-warm'
   );
 
 export const daySelectionBarClass =

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -55,7 +55,7 @@ export const dayDowClass = (
 export const dayDateClass = (
   isSelected: boolean,
   isToday: boolean,
-  dow: number
+  _dow: number
 ) =>
   cn(
     'text-[11px] font-[500] tabular-nums leading-none',

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.styles.ts
@@ -1,6 +1,6 @@
 import { cn } from '@/utils/cn';
 
-export const dayBarContainerClass = 'flex flex-col';
+export const dayBarContainerClass = 'flex flex-col bg-surface';
 
 export const topBarClass = 'flex items-center justify-between px-4 pt-3 pb-2.5';
 
@@ -27,8 +27,8 @@ export const dayGridClass = 'grid grid-cols-7 gap-1 px-2 pb-1';
 
 export const dayColumnClass = (isSelected: boolean) =>
   cn(
-    'relative flex min-h-[44px] cursor-pointer flex-col items-center justify-center gap-1 rounded-t-lg py-2.5 transition-colors',
-    isSelected ? 'hover:bg-line/60' : 'hover:bg-surface-warm'
+    'relative flex min-h-[44px] cursor-pointer flex-col items-center justify-center gap-1 py-2.5 transition-colors',
+    isSelected ? 'hover:bg-line/50' : 'hover:bg-line/25'
   );
 
 export const daySelectionBarClass =
@@ -41,17 +41,25 @@ export const dayDowClass = (
 ) =>
   cn(
     'text-[13px] font-[700] leading-none',
-    isSelected
-      ? 'text-ink'
-      : isToday
-        ? 'text-accent-text'
-        : dow === 0 || dow === 6
-          ? 'text-muted'
-          : 'text-ink-2'
+    isSelected && isToday
+      ? 'text-accent-text'
+      : isSelected
+        ? 'text-ink'
+        : isToday
+          ? 'text-accent-text'
+          : dow === 0 || dow === 6
+            ? 'text-muted'
+            : 'text-ink-2'
   );
 
 export const dayDateClass = (isSelected: boolean, isToday: boolean) =>
   cn(
     'text-[11px] font-[500] tabular-nums leading-none',
-    isSelected ? 'text-ink-2' : isToday ? 'text-accent-text' : 'text-muted'
+    isSelected && isToday
+      ? 'text-accent-text'
+      : isSelected
+        ? 'text-ink-2'
+        : isToday
+          ? 'text-accent-text'
+          : 'text-muted'
   );

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { sendGAEvent } from '@next/third-parties/google';
+import { trackEvent } from '@/utils/ga';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useEffect } from 'react';
 import toast from 'react-hot-toast';
@@ -76,7 +76,7 @@ const MenuBoardDayBar = () => {
                 toast('지난주까지만 볼 수 있어요');
                 return;
               }
-              sendGAEvent('event', 'week_navigate', { direction: 'prev' });
+              trackEvent('event', 'week_navigate', { direction: 'prev' });
               goToPrevWeek();
             }}
             aria-label="지난주 메뉴 보기"
@@ -99,7 +99,7 @@ const MenuBoardDayBar = () => {
                 toast('영양사 선생님이 아직 고민 중이에요');
                 return;
               }
-              sendGAEvent('event', 'week_navigate', { direction: 'next' });
+              trackEvent('event', 'week_navigate', { direction: 'next' });
               goToNextWeek();
             }}
             aria-label="다음주 메뉴 보기"
@@ -120,7 +120,7 @@ const MenuBoardDayBar = () => {
               key={day.format('YYYY-MM-DD')}
               type="button"
               onClick={() => {
-                sendGAEvent('event', 'day_select', {
+                trackEvent('event', 'day_select', {
                   offset: day.diff(today, 'day'),
                 });
                 setSelectedDate(day);

--- a/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardDayBar/MenuBoardDayBar.tsx
@@ -137,7 +137,7 @@ const MenuBoardDayBar = () => {
               </span>
               <span
                 suppressHydrationWarning
-                className={dayDateClass(isSelected, isToday, dow)}
+                className={dayDateClass(isSelected, isToday)}
               >
                 {day.date()}
               </span>

--- a/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import { Plane, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 
-import { Plane, Sparkles } from 'lucide-react';
 
 import {
   BOARD_EMPTY_COPY,

--- a/src/components/news/NewsFilter/NewsFilter.tsx
+++ b/src/components/news/NewsFilter/NewsFilter.tsx
@@ -1,14 +1,15 @@
 'use client';
 
+import { ChevronDown, Clock, Loader2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
-import { ChevronDown, Clock, Loader2 } from 'lucide-react';
 
-import type { CompanyNews } from '@/models/news';
 import dayjs from '@/lib/dayjs';
+import type { CompanyNews } from '@/models/news';
 import { formatRelativeDate } from '@/utils/date';
 
 import NewsCard from '../NewsCard';
+
 import { FILTER_OPTIONS } from './NewsFilter.constants';
 import {
   crawledAtIconClass,

--- a/src/components/notice/NoticeBody/NoticeBody.tsx
+++ b/src/components/notice/NoticeBody/NoticeBody.tsx
@@ -3,7 +3,6 @@ import ReactMarkdown from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
 
-import type { NoticeBodyProps } from './NoticeBody.types';
 import {
   blockquoteClass,
   codeClass,
@@ -19,6 +18,7 @@ import {
   ulClass,
   wrapperClass,
 } from './NoticeBody.styles';
+import type { NoticeBodyProps } from './NoticeBody.types';
 
 const NoticeBody = ({ body }: NoticeBodyProps) => (
   <div className={wrapperClass}>

--- a/src/hooks/usePick.ts
+++ b/src/hooks/usePick.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { sendGAEvent } from '@next/third-parties/google';
+import { trackEvent } from '@/utils/ga';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { PickResult, PickType } from '@/models/vote';
@@ -106,7 +106,7 @@ export const usePick = (date: string, { enabled = true } = {}) => {
           body: JSON.stringify({ date, pick_type: isSame ? null : pick_type }),
         });
         if (!res.ok) throw new Error('submit failed');
-        sendGAEvent('event', 'menu_pick', {
+        trackEvent('event', 'menu_pick', {
           pick_type: isSame ? null : pick_type,
           action: isSame ? 'cancel' : prev !== null ? 'change' : 'select',
           date,

--- a/src/hooks/useRenewalFeedback.ts
+++ b/src/hooks/useRenewalFeedback.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { sendGAEvent } from '@next/third-parties/google';
+import { trackEvent } from '@/utils/ga';
 import { usePathname } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -36,14 +36,14 @@ export const useRenewalFeedback = (version: string) => {
   }, [state]);
 
   const toggle = useCallback(() => {
-    if (!isOpen) sendGAEvent('event', 'feedback_open', {});
+    if (!isOpen) trackEvent('event', 'feedback_open', {});
     setIsOpen((v) => !v);
   }, [isOpen]);
 
   const close = useCallback(() => setIsOpen(false), []);
 
   const dismiss = useCallback(() => {
-    sendGAEvent('event', 'feedback_dismiss', {});
+    trackEvent('event', 'feedback_dismiss', {});
     localStorage.setItem(LS_DISMISSED(version), 'true');
     setVisible(false);
     setIsOpen(false);
@@ -73,7 +73,7 @@ export const useRenewalFeedback = (version: string) => {
       if (!res.ok) throw new Error('submit failed');
 
       setState('submitted');
-      sendGAEvent('event', 'feedback_submit', {
+      trackEvent('event', 'feedback_submit', {
         score,
         has_reason: !!reason.trim(),
         page: pathname,

--- a/src/hooks/useVote.ts
+++ b/src/hooks/useVote.ts
@@ -1,4 +1,4 @@
-import { sendGAEvent } from '@next/third-parties/google';
+import { trackEvent } from '@/utils/ga';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { VoteResult, VoteType } from '@/models/vote';
@@ -144,7 +144,7 @@ export const useVotes = (date: string, { enabled = true } = {}) => {
           }),
         });
         if (!res.ok) throw new Error('vote failed');
-        sendGAEvent('event', 'menu_vote', {
+        trackEvent('event', 'menu_vote', {
           vote_type: isSame ? 'cancel' : voteType,
           course: menuKey.split('_').slice(1).join('_'),
           date: menuKey.split('_')[0],

--- a/src/utils/ga.ts
+++ b/src/utils/ga.ts
@@ -1,0 +1,6 @@
+import { sendGAEvent } from '@next/third-parties/google';
+
+export const trackEvent = (...args: Parameters<typeof sendGAEvent>): void => {
+  if (process.env.NODE_ENV !== 'production') return;
+  sendGAEvent(...args);
+};

--- a/src/utils/jsonLd.ts
+++ b/src/utils/jsonLd.ts
@@ -1,6 +1,5 @@
-import { SITE_URL } from '@/utils/env';
-
 import { SITE_NAME } from '@/constants/site';
+import { SITE_URL } from '@/utils/env';
 
 export const SITE_DESC =
   '메가존 구내식당·메가존클라우드 구내식당 주간 식단표를 한눈에. 코스1·코스2·테이크아웃 메뉴 조회, 실시간 운영 상태 확인, 맛 평가 투표까지.';

--- a/src/utils/noticePolicy.ts
+++ b/src/utils/noticePolicy.ts
@@ -1,6 +1,8 @@
+import dayjs from '@/lib/dayjs';
 import type { Notice } from '@/models/notice';
 
 const NOTICE_READ_KEY = 'notice-read';
+const NEW_NOTICE_THRESHOLD_DAYS = 7;
 
 export const getReadNoticeIds = (): string[] => {
   if (typeof window === 'undefined') return [];
@@ -29,4 +31,12 @@ export const markNoticeRead = (id: string): void => {
 export const hasNewNotice = (
   notices: Notice[],
   readIds: string[] = []
-): boolean => notices.length > 0 && !readIds.includes(notices[0].id);
+): boolean => {
+  if (notices.length === 0) return false;
+  const top = notices[0];
+  if (readIds.includes(top.id)) return false;
+  return (
+    dayjs().tz().diff(dayjs.tz(top.publishedAt), 'day') <
+    NEW_NOTICE_THRESHOLD_DAYS
+  );
+};


### PR DESCRIPTION
## 개요

> **한줄 요약**: 날짜 그리드 배경·호버·텍스트 컬러를 다듬고, GA 이벤트를 프로덕션 환경에서만 집계되도록 분리

날짜 그리드가 페이지 배경과 구분이 안 되는 문제를 `bg-surface`로 해결하고, 오늘 날짜 선택 시 accent 컬러가 사라지던 버그를 수정. 코스 탭과 날짜 셀의 `rounded-lg`를 제거해 디자인 시스템 풀 스퀘어 원칙을 적용. GA 이벤트는 개발 환경 노이즈를 막기 위해 `trackEvent` 래퍼로 일원화.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **날짜 그리드 스타일** | `MenuBoardDayBar.styles.ts` | bg-surface 배경 추가, 오늘+선택 시 accent 텍스트 유지, hover bg-line, border-radius 제거 |
| **코스 탭 스타일** | `MenuBoard.styles.ts` | rounded-lg 제거 |
| **GA 래퍼** | `ga.ts`, `MenuBoardDayBar.tsx`, `usePick.ts`, `useVote.ts`, `useRenewalFeedback.ts` | trackEvent 래퍼로 교체, NODE_ENV 프로덕션 전용 |
| **Import 정렬** | `DesktopNav.tsx` | NavComingSoonItem import 순서 수정 |

&nbsp;

## 실행 흐름

단순 스타일·유틸 변경으로 별도 흐름 없음.

&nbsp;

## 테스트 계획

- [ ] 날짜 그리드 배경이 페이지 배경과 구분되는지 확인
- [ ] 오늘 날짜 선택 시 accent 텍스트 컬러 유지되는지 확인
- [ ] 날짜 셀·코스 탭 border-radius 0 적용 확인
- [ ] 로컬에서 GA 이벤트가 콘솔에 찍히지 않는지 확인
- [ ] 기존 기능 미영향 확인

---

> 🎭 **오늘의 커밋 시**
>
> 🟨 배경 없이 떠있던 날짜,
> 🔲 radius 없애니 각이 잡히고,
> 📊 GA는 프로덕션만 받으니,
> 🎨 픽셀 하나하나 제자리 찾아가네

🤖 Generated with [Claude Code](https://claude.com/claude-code)