### PR TITLE
feat: [GA] 이스터에그·슬랙봇 GA 이벤트 추가

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -1,6 +1,8 @@
+import { after } from 'next/server';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { MenuType } from '@/models/menu';
+import { trackServerEvent } from '@/utils/gaServer';
 
 import { getCachedMenu, toDateInfo, toSlackFormat } from './_utils';
 
@@ -35,6 +37,8 @@ export const POST = async (req: NextRequest) => {
   }
 
   const textResponse = toSlackFormat(menus, keyword, date);
+
+  after(() => trackServerEvent('slack_bot_call', { keyword, date }));
 
   return NextResponse.json({
     response_type: 'in_channel',

--- a/src/components/@shared/ConsoleArt/ConsoleArt.tsx
+++ b/src/components/@shared/ConsoleArt/ConsoleArt.tsx
@@ -6,7 +6,7 @@ import { CONSOLE_ART, CONSOLE_ART_STYLE } from './ConsoleArt.constants';
 
 const ConsoleArt = () => {
   useEffect(() => {
-    console.log(`%c${  CONSOLE_ART}`, CONSOLE_ART_STYLE);
+    console.log(`%c${CONSOLE_ART}`, CONSOLE_ART_STYLE);
   }, []);
 
   return null;

--- a/src/components/games/GameCard/GameCard.tsx
+++ b/src/components/games/GameCard/GameCard.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 
 import type { GameDef } from '@/constants/games';
+import { trackEvent } from '@/utils/ga';
 
 import {
   cardBadgeClass,
@@ -34,6 +35,9 @@ const GameCard = ({ slug, name, description, status }: GameDef) => {
     const next = clickCount + 1;
     setClickCount(next);
     const easter = next >= EASTER_EGG_THRESHOLD;
+    if (easter && !isEasterEgg) {
+      trackEvent('event', 'easter_egg_gamecard', { slug });
+    }
     setIsEasterEgg(easter);
     setToastVisible(true);
     setTimeout(() => setToastVisible(false), 2000);

--- a/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
@@ -3,6 +3,7 @@
 import { Plane, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 
+import { trackEvent } from '@/utils/ga';
 
 import {
   BOARD_EMPTY_COPY,
@@ -29,9 +30,13 @@ const MenuBoardEmpty = ({
   const [planeCount, setPlaneCount] = useState(INITIAL_PLANE_COUNT);
 
   const handlePlaneClick = () => {
-    setPlaneCount((prev) =>
-      prev >= PLANE_CONFIGS.length ? INITIAL_PLANE_COUNT : prev + 1
-    );
+    const next =
+      planeCount >= PLANE_CONFIGS.length ? INITIAL_PLANE_COUNT : planeCount + 1;
+    trackEvent('event', 'easter_egg_airplane', {
+      plane_count: next,
+      is_max: next >= PLANE_CONFIGS.length,
+    });
+    setPlaneCount(next);
   };
 
   const closedTitle = (() => {

--- a/src/hooks/useEasterEgg.ts
+++ b/src/hooks/useEasterEgg.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { trackEvent } from '@/utils/ga';
+
 export type EggStep = 0 | 1 | 2;
 
 const THRESHOLD = 5;
@@ -31,11 +33,16 @@ export const useEasterEgg = () => {
       clickCountRef.current = 0;
       setTriggered(true);
       setClickCount(0);
+      trackEvent('event', 'easter_egg_confetti', { trigger: 'course_label' });
       return;
     }
 
     clickCountRef.current = next;
     setClickCount(next);
+    const nextStep = calcEggStep(next);
+    if (nextStep > 0) {
+      trackEvent('event', 'easter_egg_confetti_progress', { step: nextStep });
+    }
     resetTimerRef.current = setTimeout(() => {
       clickCountRef.current = 0;
       setClickCount(0);

--- a/src/utils/gaServer.ts
+++ b/src/utils/gaServer.ts
@@ -1,0 +1,27 @@
+const GA_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
+
+export const trackServerEvent = async (
+  eventName: string,
+  params: Record<string, unknown> = {}
+): Promise<void> => {
+  const measurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+  const apiSecret = process.env.GA_API_SECRET;
+  if (!measurementId || !apiSecret || process.env.NODE_ENV !== 'production')
+    return;
+
+  try {
+    await fetch(
+      `${GA_ENDPOINT}?measurement_id=${measurementId}&api_secret=${apiSecret}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          client_id: 'server',
+          events: [{ name: eventName, params }],
+        }),
+      }
+    );
+  } catch {
+    // silent — GA 실패가 API 응답을 막으면 안 됨
+  }
+};


### PR DESCRIPTION
## 개요

> **한줄 요약**: 이스터에그 3종과 슬랙봇 호출에 GA 이벤트를 추가해 어떤 숨겨진 기능이 얼마나 발견되는지 파악한다.

기존 GA에는 메뉴 투표·픽·주간 이동 이벤트만 있었고, 이스터에그(confetti, 비행기, GameCard)와 슬랙봇 사용량은 완전한 사각지대였다.
슬랙봇은 서버사이드라 브라우저 gtag를 쓸 수 없어 GA4 Measurement Protocol을 사용한다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **이스터에그 (클라이언트)** | `useEasterEgg.ts` | confetti 발화·progress 단계 트래킹 추가 |
| **이스터에그 (클라이언트)** | `MenuBoardEmpty.tsx` | 비행기 클릭 트래킹 추가 (setState 외부로 분리) |
| **이스터에그 (클라이언트)** | `GameCard.tsx` | coming-soon 이스터에그 첫 발화 트래킹 추가 |
| **슬랙봇 (서버)** | `route.ts`, `gaServer.ts` | Measurement Protocol로 슬랙봇 호출 트래킹, `after()`로 응답 지연 없이 전송 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 슬랙봇
    participant SlackRoute as /api/slack
    participant GA서버 as GA Measurement Protocol

    슬랙봇->>SlackRoute: POST /api/slack
    SlackRoute-->>슬랙봇: 메뉴 응답 (즉시)
    SlackRoute--)GA서버: after() → trackServerEvent('slack_bot_call')
```

&nbsp;

## 주요 리뷰 요청사항

- `gaServer.ts`의 `client_id: 'server'` — 슬랙봇 호출은 유저 단위 분석이 불필요해 정적 값으로 처리. GA4 이벤트 카운트 용도로만 쓸 경우 괜찮지만, 세션·유저 지표가 필요하면 요청별 UUID로 교체 필요.

&nbsp;

## 테스트 계획

- [ ] 코스 레이블 5회 연속 클릭 → GA `easter_egg_confetti` 이벤트 확인 (GA4 실시간)
- [ ] 3·4회 클릭 시 `easter_egg_confetti_progress` step 1·2 확인
- [ ] 휴무일 화면 비행기 클릭 → `easter_egg_airplane` plane_count·is_max 확인
- [ ] 준비중 게임 카드 5회 클릭 → `easter_egg_gamecard` slug 확인
- [ ] 슬랙에서 `/megabobs` 실행 → GA4 실시간에서 `slack_bot_call` 확인
- [ ] 기존 이벤트 (week_navigate, menu_vote, menu_pick) 정상 동작 확인

---

> 🎭 **오늘의 커밋 시**
>
> 이스터에그를 몇 명이나 찾았을까 🥚
> 비행기는 몇 번 클릭했을까 ✈️
> 이제 GA가 조용히 세고 있어
> after()에 맡기고 응답은 먼저 🚀
> 숫자로 증명되는 숨은 재미들 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)