### PR TITLE
chore: [GA] 이스터에그·슬랙봇 GA 이벤트 추가

### DIFF
--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -1,6 +1,8 @@
+import { after } from 'next/server';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { MenuType } from '@/models/menu';
+import { trackServerEvent } from '@/utils/gaServer';
 
 import { getCachedMenu, toDateInfo, toSlackFormat } from './_utils';
 
@@ -35,6 +37,8 @@ export const POST = async (req: NextRequest) => {
   }
 
   const textResponse = toSlackFormat(menus, keyword, date);
+
+  after(() => trackServerEvent('slack_bot_call', { keyword, date }));
 
   return NextResponse.json({
     response_type: 'in_channel',

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -1,5 +1,4 @@
-import { after } from 'next/server';
-import { NextRequest, NextResponse } from 'next/server';
+import { after, NextRequest, NextResponse } from 'next/server';
 
 import { MenuType } from '@/models/menu';
 import { trackServerEvent } from '@/utils/gaServer';

--- a/src/components/@shared/ConsoleArt/ConsoleArt.tsx
+++ b/src/components/@shared/ConsoleArt/ConsoleArt.tsx
@@ -6,7 +6,7 @@ import { CONSOLE_ART, CONSOLE_ART_STYLE } from './ConsoleArt.constants';
 
 const ConsoleArt = () => {
   useEffect(() => {
-    console.log(`%c${  CONSOLE_ART}`, CONSOLE_ART_STYLE);
+    console.log(`%c${CONSOLE_ART}`, CONSOLE_ART_STYLE);
   }, []);
 
   return null;

--- a/src/components/games/GameCard/GameCard.tsx
+++ b/src/components/games/GameCard/GameCard.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 
 import type { GameDef } from '@/constants/games';
+import { trackEvent } from '@/utils/ga';
 
 import {
   cardBadgeClass,
@@ -34,6 +35,9 @@ const GameCard = ({ slug, name, description, status }: GameDef) => {
     const next = clickCount + 1;
     setClickCount(next);
     const easter = next >= EASTER_EGG_THRESHOLD;
+    if (easter && !isEasterEgg) {
+      trackEvent('event', 'easter_egg_gamecard', { slug });
+    }
     setIsEasterEgg(easter);
     setToastVisible(true);
     setTimeout(() => setToastVisible(false), 2000);

--- a/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
@@ -3,6 +3,7 @@
 import { Plane, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 
+import { trackEvent } from '@/utils/ga';
 
 import {
   BOARD_EMPTY_COPY,
@@ -29,9 +30,13 @@ const MenuBoardEmpty = ({
   const [planeCount, setPlaneCount] = useState(INITIAL_PLANE_COUNT);
 
   const handlePlaneClick = () => {
-    setPlaneCount((prev) =>
-      prev >= PLANE_CONFIGS.length ? INITIAL_PLANE_COUNT : prev + 1
-    );
+    const next =
+      planeCount >= PLANE_CONFIGS.length ? INITIAL_PLANE_COUNT : planeCount + 1;
+    trackEvent('event', 'easter_egg_airplane', {
+      plane_count: next,
+      is_max: next >= PLANE_CONFIGS.length,
+    });
+    setPlaneCount(next);
   };
 
   const closedTitle = (() => {

--- a/src/hooks/useEasterEgg.ts
+++ b/src/hooks/useEasterEgg.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { trackEvent } from '@/utils/ga';
+
 export type EggStep = 0 | 1 | 2;
 
 const THRESHOLD = 5;
@@ -31,11 +33,16 @@ export const useEasterEgg = () => {
       clickCountRef.current = 0;
       setTriggered(true);
       setClickCount(0);
+      trackEvent('event', 'easter_egg_confetti', { trigger: 'course_label' });
       return;
     }
 
     clickCountRef.current = next;
     setClickCount(next);
+    const nextStep = calcEggStep(next);
+    if (nextStep > 0) {
+      trackEvent('event', 'easter_egg_confetti_progress', { step: nextStep });
+    }
     resetTimerRef.current = setTimeout(() => {
       clickCountRef.current = 0;
       setClickCount(0);

--- a/src/utils/gaServer.ts
+++ b/src/utils/gaServer.ts
@@ -1,0 +1,27 @@
+const GA_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
+
+export const trackServerEvent = async (
+  eventName: string,
+  params: Record<string, unknown> = {}
+): Promise<void> => {
+  const measurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+  const apiSecret = process.env.GA_API_SECRET;
+  if (!measurementId || !apiSecret || process.env.NODE_ENV !== 'production')
+    return;
+
+  try {
+    await fetch(
+      `${GA_ENDPOINT}?measurement_id=${measurementId}&api_secret=${apiSecret}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          client_id: 'server',
+          events: [{ name: eventName, params }],
+        }),
+      }
+    );
+  } catch {
+    // silent — GA 실패가 API 응답을 막으면 안 됨
+  }
+};


### PR DESCRIPTION
## 개요

> **한줄 요약**: 이스터에그 3종과 슬랙봇 호출에 Google Analytics 이벤트를 추가합니다.

사용자 행동 데이터를 수집하기 위해 이스터에그(비행기·컨페티·게임카드)와 슬랙봇 호출 시 GA 이벤트를 기록합니다. 서버 사이드 이벤트는 `next/server`의 `after()`를 활용해 응답 지연 없이 비동기로 전송합니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **서버 GA 유틸** | `gaServer.ts` | Measurement Protocol 기반 서버 이벤트 전송 함수 신규 추가 |
| **슬랙봇 GA** | `route.ts` | 슬래시 커맨드 호출 시 `slack_bot_call` 이벤트 기록 |
| **이스터에그 GA** | `useEasterEgg.ts`, `MenuBoardEmpty.tsx`, `GameCard.tsx` | 컨페티·비행기·게임카드 이스터에그 발동 이벤트 기록 |
| **마크업 정리** | `ConsoleArt.tsx` | 템플릿 리터럴 공백 제거 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 슬랙사용자
    participant 슬랙API as /api/slack
    participant GA서버 as GA MP API

    슬랙사용자->>슬랙API: POST /api/slack
    슬랙API->>슬랙사용자: 메뉴 응답 반환
    슬랙API-->>GA서버: after() → trackServerEvent('slack_bot_call')
```

&nbsp;

## 테스트 계획

- [ ] 슬랙봇 `/밥` 호출 후 GA 대시보드에서 `slack_bot_call` 이벤트 확인
- [ ] 메뉴 없는 날 비행기 클릭 → `easter_egg_airplane` 이벤트 확인
- [ ] 코스 라벨 5회 클릭 → `easter_egg_confetti` 이벤트 확인
- [ ] 게임카드 이스터에그 발동 → `easter_egg_gamecard` 이벤트 확인
- [ ] 기존 메뉴 조회·투표 기능 미영향 확인

---

> 🎭 **오늘의 커밋 시**
>
> 비행기를 띄우고 🛩️ 컨페티를 뿌려도
> 아무도 몰랐다, 그 클릭들을 📊
> 이제 GA가 조용히 적어두리
> "누군가 오늘 이스터에그를 찾았습니다" 🥚

🤖 Generated with [Claude Code](https://claude.com/claude-code)