### PR TITLE
chore: [GA·CI] 이스터에그·슬랙봇 GA 이벤트 추가 및 CI 개선

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Bump version and push
@@ -54,6 +54,7 @@ jobs:
           NEW_VERSION=$(node -p "require('./package.json').version")
           git add package.json
           git commit -m "chore: bump version to v${NEW_VERSION} [skip ci]"
+          git pull --rebase origin main
           git push
           echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mega-bobs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mega-bobs",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/slack/route.ts
+++ b/src/app/api/slack/route.ts
@@ -1,6 +1,8 @@
+import { after } from 'next/server';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { MenuType } from '@/models/menu';
+import { trackServerEvent } from '@/utils/gaServer';
 
 import { getCachedMenu, toDateInfo, toSlackFormat } from './_utils';
 
@@ -35,6 +37,8 @@ export const POST = async (req: NextRequest) => {
   }
 
   const textResponse = toSlackFormat(menus, keyword, date);
+
+  after(() => trackServerEvent('slack_bot_call', { keyword, date }));
 
   return NextResponse.json({
     response_type: 'in_channel',

--- a/src/components/@shared/ConsoleArt/ConsoleArt.tsx
+++ b/src/components/@shared/ConsoleArt/ConsoleArt.tsx
@@ -6,7 +6,7 @@ import { CONSOLE_ART, CONSOLE_ART_STYLE } from './ConsoleArt.constants';
 
 const ConsoleArt = () => {
   useEffect(() => {
-    console.log(`%c${  CONSOLE_ART}`, CONSOLE_ART_STYLE);
+    console.log(`%c${CONSOLE_ART}`, CONSOLE_ART_STYLE);
   }, []);
 
   return null;

--- a/src/components/games/GameCard/GameCard.tsx
+++ b/src/components/games/GameCard/GameCard.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 
 import type { GameDef } from '@/constants/games';
+import { trackEvent } from '@/utils/ga';
 
 import {
   cardBadgeClass,
@@ -34,6 +35,9 @@ const GameCard = ({ slug, name, description, status }: GameDef) => {
     const next = clickCount + 1;
     setClickCount(next);
     const easter = next >= EASTER_EGG_THRESHOLD;
+    if (easter && !isEasterEgg) {
+      trackEvent('event', 'easter_egg_gamecard', { slug });
+    }
     setIsEasterEgg(easter);
     setToastVisible(true);
     setTimeout(() => setToastVisible(false), 2000);

--- a/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
+++ b/src/components/menu/MenuBoard/_MenuBoardEmpty/MenuBoardEmpty.tsx
@@ -3,6 +3,7 @@
 import { Plane, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 
+import { trackEvent } from '@/utils/ga';
 
 import {
   BOARD_EMPTY_COPY,
@@ -29,9 +30,13 @@ const MenuBoardEmpty = ({
   const [planeCount, setPlaneCount] = useState(INITIAL_PLANE_COUNT);
 
   const handlePlaneClick = () => {
-    setPlaneCount((prev) =>
-      prev >= PLANE_CONFIGS.length ? INITIAL_PLANE_COUNT : prev + 1
-    );
+    const next =
+      planeCount >= PLANE_CONFIGS.length ? INITIAL_PLANE_COUNT : planeCount + 1;
+    trackEvent('event', 'easter_egg_airplane', {
+      plane_count: next,
+      is_max: next >= PLANE_CONFIGS.length,
+    });
+    setPlaneCount(next);
   };
 
   const closedTitle = (() => {

--- a/src/hooks/useEasterEgg.ts
+++ b/src/hooks/useEasterEgg.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { trackEvent } from '@/utils/ga';
+
 export type EggStep = 0 | 1 | 2;
 
 const THRESHOLD = 5;
@@ -31,11 +33,16 @@ export const useEasterEgg = () => {
       clickCountRef.current = 0;
       setTriggered(true);
       setClickCount(0);
+      trackEvent('event', 'easter_egg_confetti', { trigger: 'course_label' });
       return;
     }
 
     clickCountRef.current = next;
     setClickCount(next);
+    const nextStep = calcEggStep(next);
+    if (nextStep > 0) {
+      trackEvent('event', 'easter_egg_confetti_progress', { step: nextStep });
+    }
     resetTimerRef.current = setTimeout(() => {
       clickCountRef.current = 0;
       setClickCount(0);

--- a/src/utils/gaServer.ts
+++ b/src/utils/gaServer.ts
@@ -1,0 +1,27 @@
+const GA_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
+
+export const trackServerEvent = async (
+  eventName: string,
+  params: Record<string, unknown> = {}
+): Promise<void> => {
+  const measurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+  const apiSecret = process.env.GA_API_SECRET;
+  if (!measurementId || !apiSecret || process.env.NODE_ENV !== 'production')
+    return;
+
+  try {
+    await fetch(
+      `${GA_ENDPOINT}?measurement_id=${measurementId}&api_secret=${apiSecret}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          client_id: 'server',
+          events: [{ name: eventName, params }],
+        }),
+      }
+    );
+  } catch {
+    // silent — GA 실패가 API 응답을 막으면 안 됨
+  }
+};


### PR DESCRIPTION
## 개요

> **한줄 요약**: 이스터에그·슬랙봇에 GA 이벤트를 추가하고, CI Node 버전 업그레이드 및 v1.1.1을 main에 반영합니다.

GA Measurement Protocol로 서버사이드 추적 유틸을 새로 만들고, 기존 클라이언트 이스터에그(비행기·컨페티·게임카드)와 슬랙봇 호출에 GA 이벤트를 연결했습니다.
version-bump CI의 Node 20→22 업그레이드와 push 충돌 방지 로직도 함께 포함됩니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --- | --- | --- |
| **GA 서버 유틸** | `gaServer.ts` | Measurement Protocol fetch 래퍼 신규 추가 |
| **이스터에그 GA** | `useEasterEgg.ts`, `MenuBoardEmpty.tsx`, `GameCard.tsx` | 컨페티·비행기·게임카드 클릭 이벤트 추적 |
| **슬랙봇 GA** | `route.ts` (slack) | `after()` 훅으로 슬랙 커맨드 호출 이벤트 비동기 추적 |
| **CI** | `version-bump.yml` | Node 20→22, `git pull --rebase` 충돌 방지 |
| **ConsoleArt** | `ConsoleArt.tsx` | 템플릿 리터럴 공백 lint 수정 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 슬랙봇 as 슬랙 커맨드
    participant API as /api/slack
    participant GA서버 as gaServer.ts
    participant GA as Google Analytics

    슬랙봇->>API: POST /api/slack
    API->>슬랙봇: 메뉴 응답 반환
    API-->>GA서버: after() 비동기 호출
    GA서버->>GA: Measurement Protocol POST
```

&nbsp;

## 테스트 계획

- [ ] 슬랙봇 커맨드 `/밥` 호출 후 GA DebugView에서 `slack_bot_call` 이벤트 확인
- [ ] 이스터에그 컨페티 트리거 → `easter_egg_confetti` 이벤트 확인
- [ ] 메뉴 없는 날 비행기 클릭 → `easter_egg_airplane` 이벤트 확인
- [ ] 게임카드 이스터에그 → `easter_egg_gamecard` 이벤트 확인
- [ ] 기존 메뉴 조회·투표·픽 기능 미영향 확인

---

> 🎭 **오늘의 커밋 시**
>
> 클릭 한 번에 비행기가 날고 ✈️
> 슬랙에 밥을 물으면 GA가 듣고 📊
> 서버는 조용히 구글에 속삭이네 🤫
> 버전은 1.1.1, 숫자도 이스터에그 🥚

🤖 Generated with [Claude Code](https://claude.com/claude-code)