### PR TITLE
fix: [릴리스] v1.1.3 패치 릴리스

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.VERSION_BUMP_TOKEN }}
 
       - name: Determine bump type from commit message
         id: bump
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create tag and GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.VERSION_BUMP_TOKEN }}
         run: |
           VERSION="v${{ steps.version.outputs.version }}"
           git tag "${VERSION}"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@vercel/analytics": "^1.6.1",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.13",
+    "isbot": "^5.2.0",
     "lucide-react": "^0.525.0",
     "next": "15.3.8",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
+      isbot:
+        specifier: ^5.2.0
+        version: 5.2.0
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@19.1.0)
@@ -2058,6 +2061,10 @@ packages:
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  isbot@5.2.0:
+    resolution: {integrity: sha512-gbZiGCb4B5xaoxg9mS7koAyRdvJnArk10VLSHOgz6rtBG93/pi1xOFaVvXMKZ7JXgyZ8zAbNRK5uIBdIUTFSqw==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -5341,6 +5348,8 @@ snapshots:
       get-intrinsic: 1.3.0
 
   isarray@2.0.5: {}
+
+  isbot@5.2.0: {}
 
   isexe@2.0.0: {}
 

--- a/src/utils/ga.test.ts
+++ b/src/utils/ga.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const sendGAEventMock = vi.fn();
+vi.mock('@next/third-parties/google', () => ({
+  sendGAEvent: (...args: unknown[]) => sendGAEventMock(...args),
+}));
+
+import { trackEvent } from './ga';
+
+describe('trackEvent', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it('does nothing outside production', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    trackEvent('event', 'test_event');
+
+    expect(sendGAEventMock).not.toHaveBeenCalled();
+  });
+
+  it('skips sending when navigator UA is a bot', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubGlobal('navigator', {
+      userAgent:
+        'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+    });
+
+    trackEvent('event', 'test_event');
+
+    expect(sendGAEventMock).not.toHaveBeenCalled();
+  });
+
+  it('sends the event for a normal browser UA in production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubGlobal('navigator', {
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+    });
+
+    trackEvent('event', 'test_event', { foo: 'bar' });
+
+    expect(sendGAEventMock).toHaveBeenCalledWith('event', 'test_event', {
+      foo: 'bar',
+    });
+  });
+});

--- a/src/utils/ga.ts
+++ b/src/utils/ga.ts
@@ -1,6 +1,8 @@
 import { sendGAEvent } from '@next/third-parties/google';
+import { isbot } from 'isbot';
 
 export const trackEvent = (...args: Parameters<typeof sendGAEvent>): void => {
   if (process.env.NODE_ENV !== 'production') return;
+  if (typeof navigator !== 'undefined' && isbot(navigator.userAgent)) return;
   sendGAEvent(...args);
 };

--- a/vercel.json
+++ b/vercel.json
@@ -8,5 +8,12 @@
       "path": "/api/votes/cleanup",
       "schedule": "0 0 * * *"
     }
-  ]
+  ],
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "dev": true,
+      "*": false
+    }
+  }
 }


### PR DESCRIPTION
## 개요

> **한줄 요약**: v1.1.3 패치 릴리스로 CI 버전 bump 안정화와 GA 봇 이벤트 필터링을 배포합니다.

이번 릴리스는 `main` 브랜치 보호 규칙 아래에서도 버전 bump와 릴리스 생성이 동작하도록 토큰 사용을 바로잡고, 클라이언트 GA 이벤트에서 봇 User-Agent를 제외해 지표 오염을 줄입니다. PR 제목을 `fix:`로 생성해 자동 버전 bump가 patch로 처리되도록 합니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --------- | ---- | ---- |
| **CI 릴리스 안정화** | `version-bump.yml` | `VERSION_BUMP_TOKEN`으로 checkout과 GitHub Release 생성을 수행하도록 변경 |
| **배포 제어** | `vercel.json` | `main`, `dev`만 Vercel 배포가 활성화되도록 브랜치 배포 설정 추가 |
| **GA 필터링** | `ga.ts`, `ga.test.ts` | `isbot` 기반 클라이언트 봇 이벤트 차단과 테스트 추가 |
| **의존성** | `package.json`, `pnpm-lock.yaml` | `isbot` 의존성 추가, `main`의 `1.1.2` 버전 유지 |

&nbsp;

## 실행 흐름

```mermaid
sequenceDiagram
    participant 개발 as dev
    participant 메인 as main
    participant 워크플로우 as version-bump
    participant 릴리스 as GitHub Release

    개발->>메인: fix 릴리스 PR 병합
    메인->>워크플로우: main push 이벤트 발생
    워크플로우->>워크플로우: commit message로 patch bump 판단
    워크플로우->>메인: VERSION_BUMP_TOKEN으로 v1.1.3 커밋 push
    워크플로우->>릴리스: v1.1.3 태그와 릴리스 생성
```

&nbsp;

## 주요 리뷰 요청사항

- PR 제목의 `fix:` prefix가 patch bump 의도와 맞는지 확인 부탁드립니다.
- `VERSION_BUMP_TOKEN`이 main 보호 규칙 우회 권한을 가진 PAT인지 확인 부탁드립니다.

&nbsp;

## 테스트 계획

- [x] `pnpm test`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec eslint src/utils/ga.ts src/utils/ga.test.ts .github/workflows/version-bump.yml`
- [x] `pnpm build`
- [ ] main merge 후 자동 버전 bump가 `1.1.3`으로 생성되는지 확인
- [ ] 기존 기능 미영향 확인

---

> 🎭 **오늘의 커밋 시**
>
> 작게 고친 나사 하나  
> 배포 문은 부드럽게 열리고  
> 봇의 흔적은 조용히 비켜서  
> 패치 번호만 한 칸 오른다

🤖 Generated with [Claude Code](https://claude.com/claude-code)