### PR TITLE
fix: [CI] version-bump pnpm 캐시 저장 실패 제거

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -43,7 +43,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
 
       - name: Bump version and push
         id: version


### PR DESCRIPTION
## 개요

> **한줄 요약**: version-bump 워크플로우의 pnpm 캐시 저장 실패를 제거합니다.

`version-bump.yml`은 패키지 설치 없이 `pnpm version`만 실행하므로 `actions/setup-node`의 pnpm cache 저장 대상 경로가 생성되지 않습니다. 이 때문에 버전 bump, 태그, GitHub Release 생성이 모두 성공해도 post cleanup에서 워크플로우가 실패로 표시되어 `cache: pnpm` 설정을 제거합니다.

&nbsp;

## 변경 사항

| 변경 그룹 | 파일 | 요약 |
| --------- | ---- | ---- |
| **CI 정리** | `version-bump.yml` | 설치 단계가 없는 워크플로우에서 불필요한 pnpm cache 설정 제거 |

&nbsp;

## 주요 리뷰 요청사항

- 이 워크플로우는 `pnpm install`을 실행하지 않으므로 Node cache 제거가 맞는지 확인 부탁드립니다.

&nbsp;

## 테스트 계획

- [x] `pnpm exec prettier --check .github/workflows/version-bump.yml`
- [ ] main merge 후 Auto Version Bump가 cleanup 단계까지 성공으로 완료되는지 확인
- [ ] 기존 기능 미영향 확인

---

> 🎭 **오늘의 커밋 시**
>
> 할 일 없는 캐시는 조용히 퇴장하고  
> 버전 숫자는 제 길을 간다  
> 마지막 청소까지 초록불로  
> 릴리스의 문장을 마침표로 닫는다

🤖 Generated with [Claude Code](https://claude.com/claude-code)